### PR TITLE
settings: BaseEntity와 관련 설정 및 MapStruct 의존성 추가 #32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.5.2.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.2.Final'
+
 	// DevTools
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/be3c/sysmetic/global/config/AuditConfig.java
+++ b/src/main/java/com/be3c/sysmetic/global/config/AuditConfig.java
@@ -1,0 +1,16 @@
+package com.be3c.sysmetic.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider(){
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/com/be3c/sysmetic/global/config/AuditorAwareImpl.java
+++ b/src/main/java/com/be3c/sysmetic/global/config/AuditorAwareImpl.java
@@ -1,0 +1,20 @@
+package com.be3c.sysmetic.global.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberId = "";
+        memberId = "security 구현 후 수정";
+        if(authentication != null)
+            memberId = authentication.getName();    // UserDetails의 getUsername() 반환값 -- email
+        return Optional.of(memberId);
+    }
+}

--- a/src/main/java/com/be3c/sysmetic/global/entity/BaseEntity.java
+++ b/src/main/java/com/be3c/sysmetic/global/entity/BaseEntity.java
@@ -1,0 +1,19 @@
+package com.be3c.sysmetic.global.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+@MappedSuperclass
+@Getter @Setter
+public abstract class BaseEntity extends BaseTimeEntity{
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String modifiedBy;
+}

--- a/src/main/java/com/be3c/sysmetic/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/be3c/sysmetic/global/entity/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.be3c.sysmetic.global.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+@MappedSuperclass
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
# 🚀 Pull Request
**[BaseEntity와 관련 설정 및 MapStruct 의존성 추가]**

## #️⃣ 연관된 이슈
#32

## 📋 작업 내용
- JPA Auditing 기능을 활성화하여 생성/수정 시간 및 사용자 정보를 자동으로 추적
- BaseEntity 클래스를 추가하여 공통 필드(createdAt, updatedAt, createdBy, updatedBy) 관리
- MapStruct 의존성을 추가하여 DTO와 엔티티 간의 매핑을 효율적으로 처리할 수 있도록 설정
