### PR TITLE
feature : strategy statistics #48

### DIFF
--- a/src/main/java/com/be3c/sysmetic/SysmeticApplication.java
+++ b/src/main/java/com/be3c/sysmetic/SysmeticApplication.java
@@ -3,7 +3,10 @@ package com.be3c.sysmetic;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
+@EnableScheduling
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class SysmeticApplication {
 

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/config/SchedulerConfiguration.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/config/SchedulerConfiguration.java
@@ -22,7 +22,7 @@ public class SchedulerConfiguration {
     @Scheduled(cron = "0 00 00 * * ?")
     public void run() {
 
-        // 공개 상태인 전략에 한해 전략 통계 계산
+        // 공개 상태인 전략에 한해 전략 통계 계산 -> todo 비공개 상태일 때도 트레이더는 전략 통계 확인 가능한데, 공개 상태만 계산하는 게 맞는가. 리팩토링시 고민
         List<Strategy> publicStrategies = strategyRepository.findAllByPublicStatus();
         for (Strategy strategy : publicStrategies) {
             try {

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/config/SchedulerConfiguration.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/config/SchedulerConfiguration.java
@@ -1,0 +1,35 @@
+package com.be3c.sysmetic.domain.strategy.config;
+
+import com.be3c.sysmetic.domain.strategy.entity.Strategy;
+import com.be3c.sysmetic.domain.strategy.repository.StrategyRepository;
+import com.be3c.sysmetic.domain.strategy.service.StrategyStatisticsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@Slf4j
+public class SchedulerConfiguration {
+    private final StrategyRepository strategyRepository;
+    private final StrategyStatisticsServiceImpl strategyStatisticsService;
+
+    // 매일 자정에 계산 초, 분, 시
+    @Scheduled(cron = "0 00 00 * * ?")
+    public void run() {
+
+        // 공개 상태인 전략에 한해 전략 통계 계산
+        List<Strategy> publicStrategies = strategyRepository.findAllByPublicStatus();
+        for (Strategy strategy : publicStrategies) {
+            try {
+                strategyStatisticsService.runStrategyStatistics(strategy.getId());
+            } catch (Exception e) {
+                log.error("Error processing strategy ID: " + strategy.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/config/SchedulerConfiguration.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/config/SchedulerConfiguration.java
@@ -18,11 +18,11 @@ public class SchedulerConfiguration {
     private final StrategyRepository strategyRepository;
     private final StrategyStatisticsServiceImpl strategyStatisticsService;
 
-    // 매일 자정에 계산 초, 분, 시
+    // 매일 자정에 계산 - cron 초, 분, 시
     @Scheduled(cron = "0 00 00 * * ?")
     public void run() {
 
-        // 공개 상태인 전략에 한해 전략 통계 계산 -> todo 비공개 상태일 때도 트레이더는 전략 통계 확인 가능한데, 공개 상태만 계산하는 게 맞는가. 리팩토링시 고민
+        // todo : 비공개 상태에도 트레이더는 자신의 전략 통계 확인 가능. 즉 비공개 상태인 전략도 계산 필요. -> 리팩토링시 진행
         List<Strategy> publicStrategies = strategyRepository.findAllByPublicStatus();
         for (Strategy strategy : publicStrategies) {
             try {

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/StrategyController.java
@@ -2,6 +2,7 @@ package com.be3c.sysmetic.domain.strategy.controller;
 
 import com.be3c.sysmetic.domain.strategy.service.DailyServiceImpl;
 import com.be3c.sysmetic.domain.strategy.service.MonthlyServiceImpl;
+import com.be3c.sysmetic.domain.strategy.service.StrategyStatisticsServiceImpl;
 import com.be3c.sysmetic.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ public class StrategyController {
 
     private final DailyServiceImpl dailyService;
     private final MonthlyServiceImpl monthlyService;
+    private final StrategyStatisticsServiceImpl strategyStatisticsService;
 
     // 일간데이터 조회
     @GetMapping("/strategy/daily")
@@ -33,6 +35,13 @@ public class StrategyController {
     public ResponseEntity<ApiResponse> findMonthly(@RequestParam("strategyId") Long strategyId, @RequestParam("page") Integer page, @RequestParam(value = "startYear", required = false) Integer startYear, @RequestParam(value = "startMonth", required = false) Integer startMonth, @RequestParam(value = "endYear", required = false) Integer endYear, @RequestParam(value = "endMonth", required = false) Integer endMonth) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(monthlyService.findMonthly(strategyId, page, startYear, startMonth, endYear, endMonth)));
+    }
+
+    // 통계 조회
+    @GetMapping("/strategy/statistics")
+    public ResponseEntity<ApiResponse> findStatistics(@RequestParam("strategyId") Long strategyId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(strategyStatisticsService.findStrategyStatistics(strategyId)));
     }
 
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/StrategyController.java
@@ -23,6 +23,8 @@ public class StrategyController {
     private final MonthlyServiceImpl monthlyService;
     private final StrategyStatisticsServiceImpl strategyStatisticsService;
 
+    // todo : 페이지 response 변경 필요. -> 리팩토링시 진행
+
     // 일간데이터 조회
     @GetMapping("/strategy/daily")
     public ResponseEntity<ApiResponse> findDaily(@RequestParam("strategyId") Long strategyId, @RequestParam("page") int page, @RequestParam(value = "startDate", required = false) LocalDateTime startDate, @RequestParam(value = "endDate", required = false) LocalDateTime endDate) {

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/StrategyController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
@@ -40,8 +37,8 @@ public class StrategyController {
     }
 
     // 통계 조회
-    @GetMapping("/strategy/statistics")
-    public ResponseEntity<ApiResponse> findStatistics(@RequestParam("strategyId") Long strategyId) {
+    @GetMapping("/strategy/statistics/{strategyId}")
+    public ResponseEntity<ApiResponse> findStatistics(@PathVariable Long strategyId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(strategyStatisticsService.findStrategyStatistics(strategyId)));
     }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
@@ -40,8 +40,8 @@ public class TraderStrategyController {
     }
 
     // 전략명 중복 확인
-    @GetMapping("/strategy/duplication-name")
-    public ResponseEntity<ApiResponse<Boolean>> checkDuplicationStrategyName(@RequestParam String name) {
+    @GetMapping("/strategy/duplication-name/{name}")
+    public ResponseEntity<ApiResponse<Boolean>> checkDuplicationStrategyName(@PathVariable String name) {
         boolean isDuplication = insertStrategyService.returnIsDuplicationName(name);
         // 중복 true, 미중복 false 반환
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
@@ -29,6 +29,8 @@ public class TraderStrategyController {
     private final DeleteStrategyServiceImpl deleteStrategyService;
     private final DailyServiceImpl dailyService;
 
+    // todo : 종목, 매매방식 조회 controller 추가, 트레이더 검증 로직 추가 필요. -> 리팩토링시 진행
+
     // 전략 등록
     @PostMapping("/strategy")
     public ResponseEntity<ApiResponse<Strategy>> insertStrategy(@Valid @RequestBody SaveStrategyRequestDto requestDto) {
@@ -37,7 +39,7 @@ public class TraderStrategyController {
                 .body(ApiResponse.success());
     }
 
-    // 전략명 중복
+    // 전략명 중복 확인
     @GetMapping("/strategy/duplication-name")
     public ResponseEntity<ApiResponse<Boolean>> checkDuplicationStrategyName(@RequestParam String name) {
         boolean isDuplication = insertStrategyService.returnIsDuplicationName(name);

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/dto/StrategyStatisticsResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/dto/StrategyStatisticsResponseDto.java
@@ -1,0 +1,51 @@
+package com.be3c.sysmetic.domain.strategy.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@ToString
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class StrategyStatisticsResponseDto {
+
+    private Double currentBalance; // 잔고
+    private Double accumulatedDepositWithdrawalAmount; // 누적입출금액
+    private Double principal; // 원금
+    private String operationPeriod; // 운용기간
+    private LocalDate startDate; // 시작일자
+    private LocalDate endDate; // 최종일자
+
+    private Double accumulatedProfitLossAmount; // 누적손익금액
+    private Double accumulatedProfitLossRate; // 누적손익률
+    private Double maximumAccumulatedProfitLossAmount; // 최대누적손익금액
+    private Double maximumAccumulatedProfitLossRate; // 최대누적손익률
+
+    private Double currentCapitalReductionAmount; // 현재자본인하금액
+    private Double currentCapitalReductionRate; // 현재자본인하율
+    private Double maximumCapitalReductionAmount; // 최대자본인하금액
+    private Double maximumCapitalReductionRate; // 최대자본인하율
+
+    private Double averageProfitLossAmount; // 평균손익금액
+    private Double averageProfitLossRate; // 평균손익률
+    private Double maximumDailyProfitAmount; // 최대일이익금액
+    private Double maximumDailyProfitRate; // 최대일이익률
+    private Double maximumDailyLossAmount; // 최대일손실금액
+    private Double maximumDailyLossRate; // 최대일손실률
+
+    private Long totalTradingDays; // 총매매일수
+    private Long totalProfitDays; // 총이익일수
+    private Long totalLossDays; // 총손실일수
+    private Long currentContinuousProfitLossDays; // 현재연속손익일수
+    private Long maxContinuousProfitDays; // 최대연속이익일수
+    private Long maxContinuousLossDays; // 최대연속손실일수
+
+    private Double winningRate; // 승률
+    private Double profitFactor;
+    private Double roa;
+    private Long highPointRenewalProgress; // 고점갱신후경과일
+
+}

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/entity/Stock.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/entity/Stock.java
@@ -26,7 +26,7 @@ public class Stock extends BaseEntity {
     @Column(name = "status_code", nullable = false)
     private String statusCode;
 
-    @Column(name = "code", nullable = false)
+    @Column(name = "code")
     private String code;
 
     @Column(name = "country")

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/entity/StrategyStatistics.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/entity/StrategyStatistics.java
@@ -18,6 +18,39 @@ import java.time.LocalDateTime;
 @Table(name = "strategy_statistics")
 public class StrategyStatistics extends BaseEntity {
 
+    /*
+        StrategyStatistics : 전략 통계
+
+        id : 전략 id
+        currentBalance : 잔고
+        principal : 원금
+        accumulatedDepositWithdrawalAmount : 누적입출금액
+        accumulatedProfitLossAmount : 누적손익금액
+        accumulatedProfitLossRate : 누적손익률
+        currentCapitalReductionAmount : 현재자본인하금액
+        currentCapitalReductionRate : 현재자본인하율
+        maximumCapitalReductionAmount: 최대자본인하금액
+        maximumCapitalReductionRate : 최대자본인하율
+        averageProfitLossAmount : 평균손익금액
+        averageProfitLossRate : 평균손익률
+        maximumDailyProfitAmount : 최대일이익금액
+        maximumDailyProfitRate : 최대일이익률
+        maximumDailyLossAmount : 최대일손실금액
+        maximumDailyLossRate : 최대일손실율
+        totalTradingDays : 총매매일수
+        currentContinuousProfitLossDays : 현재연속손익일수
+        totalProfitDays : 총이익일수
+        maxContinuousProfitDays : 최대연속이익일수
+        totalLossDays : 총손실일수
+        maxContinuousLossDays : 최대연속손실일수
+        winningRate : 승률
+        highPointRenewalProgress : 고점갱신후경과일
+        profitFactor :Profit Factor
+        roa : ROA
+        firstRegistrationDate : 최초등록일시
+        lastRegistrationDate : 최종등록일시
+    */
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -26,79 +59,79 @@ public class StrategyStatistics extends BaseEntity {
     private Strategy strategy;
 
     @Column(name = "current_balance", nullable = false)
-    private Double currentBalance;
+    private Double currentBalance; // 잔고
 
     @Column(name = "principal", nullable = false)
-    private Double principal;
+    private Double principal; // 원금
 
     @Column(name = "accumulated_deposit_withdrawal_amount", nullable = false)
-    private Double accumulatedDepositWithdrawalAmount;
+    private Double accumulatedDepositWithdrawalAmount; // 누적입출입금
 
     @Column(name = "accumulated_profit_loss_amount", nullable = false)
-    private Double accumulatedProfitLossAmount;
+    private Double accumulatedProfitLossAmount; // 누적손익금
 
     @Column(name = "accumulated_profit_loss_rate", nullable = false)
-    private Double accumulatedProfitLossRate;
+    private Double accumulatedProfitLossRate; // 누적손익률
 
-    @Column(name = "accumulated_profit_amount", nullable = false)
-    private Double accumulatedProfitAmount;
+    @Column(name = "maximum_accumulated_profit_loss_amount", nullable = false)
+    private Double maximumAccumulatedProfitLossAmount; // 최대누적손익금
 
-    @Column(name = "accumulated_profit_rate", nullable = false)
-    private Double accumulatedProfitRate;
+    @Column(name = "maximum_accumulated_profit_loss_rate", nullable = false)
+    private Double maximumAccumulatedProfitLossRate; // 최대누적손익금
 
     @Column(name = "current_capital_reduction_amount", nullable = false)
-    private Double currentCapitalReductionAmount;
+    private Double currentCapitalReductionAmount; // 현재자본인하금액
 
     @Column(name = "current_capital_reduction_rate", nullable = false)
-    private Double currentCapitalReductionRate;
+    private Double currentCapitalReductionRate; // 현재자본인하율
 
     @Column(name = "maximum_capital_reduction_amount", nullable = false)
-    private Double maximumCapitalReductionAmount;
+    private Double maximumCapitalReductionAmount; // 최대자본인하금액
 
     @Column(name = "maximum_capital_reduction_rate", nullable = false)
-    private Double maximumCapitalReductionRate;
+    private Double maximumCapitalReductionRate; // 최대자본인하율
 
     @Column(name = "average_profit_loss_amount", nullable = false)
-    private Double averageProfitLossAmount;
+    private Double averageProfitLossAmount; // 평균손익금
 
     @Column(name = "average_profit_loss_rate", nullable = false)
-    private Double averageProfitLossRate;
+    private Double averageProfitLossRate; // 평균손익률
 
     @Column(name = "maximum_daily_profit_amount", nullable = false)
-    private Double maximumDailyProfitAmount;
+    private Double maximumDailyProfitAmount; // 최대일이익금
 
     @Column(name = "maximum_daily_profit_rate", nullable = false)
-    private Double maximumDailyProfitRate;
+    private Double maximumDailyProfitRate; // 최대일이익율
 
     @Column(name = "maximum_daily_loss_amount", nullable = false)
-    private Double maximumDailyLossAmount;
+    private Double maximumDailyLossAmount; // 최대일손실금
 
     @Column(name = "maximum_daily_loss_rate", nullable = false)
-    private Double maximumDailyLossRate;
+    private Double maximumDailyLossRate; // 최대일손실율
 
     @Column(name = "total_trading_days", nullable = false)
-    private Long totalTradingDays;
+    private Long totalTradingDays; // 총매매일수
 
     @Column(name = "current_continuous_profit_loss_days", nullable = false)
-    private Long currentContinuousProfitLossDays;
+    private Long currentContinuousProfitLossDays; // 현재연속손익일수
 
     @Column(name = "total_profit_days", nullable = false)
-    private Long totalProfitDays;
+    private Long totalProfitDays; // 총이익일수
 
     @Column(name = "max_continuous_profit_days", nullable = false)
-    private Long maxContinuousProfitDays;
+    private Long maximumContinuousProfitDays; // 최대연속이익일수
 
     @Column(name = "total_loss_days", nullable = false)
-    private Long totalLossDays;
+    private Long totalLossDays; // 총손실일수
 
     @Column(name = "max_continuous_loss_days", nullable = false)
-    private Long maxContinuousLossDays;
+    private Long maximumContinuousLossDays; // 최대연속손실일수
 
     @Column(name = "winning_rate", nullable = false)
-    private Double winningRate;
+    private Double winningRate; // 승률
 
     @Column(name = "high_point_renewal_progress", nullable = false)
-    private LocalDateTime highPointRenewalProgress;
+    private Long highPointRenewalProgress; // 고점갱신후경과일
 
     @Column(name = "profit_factor", nullable = false)
     private Double profitFactor;
@@ -106,18 +139,12 @@ public class StrategyStatistics extends BaseEntity {
     @Column(name = "roa", nullable = false)
     private Double roa;
 
-    @Column(name = "last_year_profit_rate", nullable = false)
-    private Double lastYearProfitRate;
-
-    @Column(name = "standard_deviation", nullable = false)
-    private Double standardDeviation;
-
     @CreatedDate
     @Column(name = "first_registration_date", nullable = false)
-    private LocalDateTime firstRegistrationDate;
+    private LocalDateTime firstRegistrationDate; // 최초등록일시
 
     @LastModifiedDate
     @Column(name = "last_registration_date", nullable = false)
-    private LocalDateTime lastRegistrationDate;
+    private LocalDateTime lastRegistrationDate; // 최종등록일시
 
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/entity/StrategyStatistics.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/entity/StrategyStatistics.java
@@ -65,7 +65,7 @@ public class StrategyStatistics extends BaseEntity {
     private Double principal; // 원금
 
     @Column(name = "accumulated_deposit_withdrawal_amount", nullable = false)
-    private Double accumulatedDepositWithdrawalAmount; // 누적입출입금
+    private Double accumulatedDepositWithdrawalAmount; // 누적입출금
 
     @Column(name = "accumulated_profit_loss_amount", nullable = false)
     private Double accumulatedProfitLossAmount; // 누적손익금
@@ -77,7 +77,7 @@ public class StrategyStatistics extends BaseEntity {
     private Double maximumAccumulatedProfitLossAmount; // 최대누적손익금
 
     @Column(name = "maximum_accumulated_profit_loss_rate", nullable = false)
-    private Double maximumAccumulatedProfitLossRate; // 최대누적손익금
+    private Double maximumAccumulatedProfitLossRate; // 최대누적손익율
 
     @Column(name = "current_capital_reduction_amount", nullable = false)
     private Double currentCapitalReductionAmount; // 현재자본인하금액

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/DailyRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/DailyRepository.java
@@ -15,6 +15,8 @@ import java.util.List;
 @Repository
 public interface DailyRepository extends JpaRepository<Daily, Long> {
 
+    // todo : 성능 최적화 필요. -> 리팩토링시 진행
+
     // 모든 일간분석데이터 목록 조회 - date 정렬
     List<Daily> findAllByStrategyIdOrderByDateDesc(Long strategyId);
 

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/DailyRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/DailyRepository.java
@@ -14,8 +14,6 @@ import java.util.List;
 
 @Repository
 public interface DailyRepository extends JpaRepository<Daily, Long> {
-    // 최신 일간분석데이터 조회 - date 정렬
-    Daily findTopByStrategyIdOrderByDateDesc(Long strategyId);
 
     // 모든 일간분석데이터 목록 조회 - date 정렬
     List<Daily> findAllByStrategyIdOrderByDateDesc(Long strategyId);
@@ -48,5 +46,137 @@ public interface DailyRepository extends JpaRepository<Daily, Long> {
             "AND YEAR(d.date) = :year " +
             "AND MONTH(d.date) = :month", nativeQuery = true)
     List<Daily> findAllByStrategyIdAndYearAndMonth(@Param("strategyId") Long strategyId, @Param("year") int year, @Param("month") int month);
+
+    // 일간분석데이터 조회 - 첫 데이터, Date 정렬
+    Daily findTopByStrategyIdOrderByDateAsc(Long strategyId);
+
+    // 일간분석데이터 조회 - 최신 데이터, date 정렬
+    Daily findTopByStrategyIdOrderByDateDesc(Long strategyId);
+
+    // 입출금액 총합 조회
+    @Query("SELECT SUM(d.depositWithdrawalAmount) FROM Daily d WHERE d.strategy.id = :strategyId")
+    Double findTotalDepositWithdrawalAmountByStrategyId(@Param("strategyId") Long strategyId);
+
+    // 손익금액 총합 조회
+    @Query("SELECT SUM(d.profitLossAmount) FROM Daily d WHERE d.strategy.id = :strategyId")
+    Double findTotalProfitLossAmountByStrategyId(@Param("strategyId") Long strategyId);
+
+    // 손익률 총합 조회
+    @Query("SELECT SUM(d.profitLossRate) FROM Daily d WHERE d.strategy.id = :strategyId")
+    Double findTotalProfitLossRateByStrategyId(@Param("strategyId") Long strategyId);
+
+    // 일간분석데이터 최대 기준가 조회
+    Daily findTopByStrategyIdOrderByStandardAmountDesc(Long strategyId);
+
+    // 일간분석데이터 총 개수 조회
+    Long countByStrategyId(Long strategyId);
+
+    // 일간분석데이터 최대일이익금액 조회
+    Daily findTopByStrategyIdOrderByProfitLossAmountDesc(Long strategyId);
+
+    // 일간분석데이터 최대일이익률 조회
+    Daily findTopByStrategyIdOrderByProfitLossRateDesc(Long strategyId);
+
+    // 일간분석데이터 최대일손실금액 조회
+    Daily findTopByStrategyIdOrderByProfitLossAmountAsc(Long strategyId);
+
+    // 일간분석데이터 최대일손실률 조회
+    Daily findTopByStrategyIdOrderByProfitLossRateAsc(Long strategyId);
+
+    // 일간분석데이터 현재연속손익일수 조회 - 손익금 + -> - 또는 - -> + 카운트
+    @Query(value = """
+    SELECT COUNT(*) 
+    FROM (
+        SELECT 
+            d.date,
+            d.profit_loss_amount,
+            @prev_sign := @curr_sign AS prev_sign,
+            @curr_sign := CASE 
+                              WHEN d.profit_loss_amount > 0 THEN 1
+                              WHEN d.profit_loss_amount < 0 THEN -1
+                              ELSE 0
+                          END AS curr_sign
+        FROM daily d
+        CROSS JOIN (SELECT @curr_sign := NULL, @prev_sign := NULL) vars
+        WHERE d.strategy_id = :strategyId
+        ORDER BY d.date DESC
+    ) sub
+    WHERE prev_sign IS NULL OR prev_sign = curr_sign;
+    """, nativeQuery = true)
+    Long findContinuousProfitLossDays(@Param("strategyId") Long strategyId);
+
+    // 일간분석데이터 총이익일수 조회 - 손익금이 양수인 데이터 카운트
+    @Query(value = "SELECT COUNT(*) FROM daily d WHERE d.strategy_id = :strategyId AND d.profit_loss_amount > 0", nativeQuery = true)
+    Long countProfitDays(@Param("strategyId") Long strategyId);
+
+    // 일간분석데이터 최대연속이익일수 조회
+    @Query(value = """
+    SELECT MAX(consecutive_days) 
+        FROM (
+            SELECT 
+                COUNT(*) AS consecutive_days
+            FROM (
+                SELECT 
+                    d.date,
+                    d.profit_loss_amount,
+                    @group_id := IF(d.profit_loss_amount >= 0, @group_id, @group_id + 1) AS group_id
+                FROM daily d
+                CROSS JOIN (SELECT @group_id := 0) vars
+                WHERE d.strategy_id = :strategyId
+                ORDER BY d.date ASC
+            ) sub
+            WHERE sub.profit_loss_amount >= 0
+            GROUP BY group_id
+        ) final;
+    """, nativeQuery = true)
+    Long findMaxConsecutiveProfitDays(@Param("strategyId") Long strategyId);
+
+    // 일간분석데이터 총손실일수 조회 - 손익금이 음수인 데이터 카운트
+    @Query(value = "SELECT COUNT(*) FROM daily d WHERE d.strategy_id = :strategyId AND d.profit_loss_amount < 0", nativeQuery = true)
+    Long countLossDays(@Param("strategyId") Long strategyId);
+
+    // 일간분석데이터 최대연속손실일수 조회
+    @Query(value = """
+    SELECT MAX(consecutive_days) 
+        FROM (
+            SELECT 
+                COUNT(*) AS consecutive_days
+            FROM (
+                SELECT 
+                    d.date,
+                    d.profit_loss_amount,
+                    @group_id := IF(d.profit_loss_amount < 0, @group_id, @group_id + 1) AS group_id
+                FROM daily d
+                CROSS JOIN (SELECT @group_id := 0) vars
+                WHERE d.strategy_id = :strategyId
+                ORDER BY d.date ASC
+            ) sub
+            WHERE sub.profit_loss_amount < 0
+            GROUP BY group_id
+        ) final;
+    """, nativeQuery = true)
+    Long findMaxConsecutiveLossDays(@Param("strategyId") Long strategyId);
+
+    @Query(value = """
+    SELECT DATEDIFF(CURDATE(), (
+        SELECT MAX(d.date)
+        FROM daily d
+        WHERE d.strategy_id = :strategyId
+          AND d.profit_loss_amount = (
+              SELECT MAX(profit_loss_amount)
+              FROM daily
+              WHERE strategy_id = :strategyId
+          )
+    )) AS daysSinceHighPoint
+    """, nativeQuery = true)
+    Long findHighPointRenewalProgress(@Param("strategyId") Long strategyId);
+
+    // 총이익금액
+    @Query("SELECT SUM(d.profitLossAmount) FROM Daily d WHERE d.strategy.id = :strategyId AND d.profitLossAmount > 0")
+    Double findTotalProfitAmountByStrategyId(@Param("strategyId") Long strategyId);
+
+    // 총손실금액
+    @Query("SELECT SUM(d.profitLossAmount) FROM Daily d WHERE d.strategy.id = :strategyId AND d.profitLossAmount < 0")
+    Double findTotalLossAmountByStrategyId(@Param("strategyId") Long strategyId);
 
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/MonthRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/MonthRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 public interface MonthRepository extends JpaRepository<Monthly, Long> {
 
     // 특정 년월의 월간분석 데이터 조회
-    // null일 경우 전체 조회
+    // year, month null일 경우 전체 조회
     @Query("SELECT m FROM Monthly m WHERE m.strategy.id = :strategyId " +
             "AND (:startYear IS NULL OR (m.yearNumber > :startYear OR (m.yearNumber = :startYear AND (:startMonth IS NULL OR m.monthNumber >= :startMonth)))) " +
             "AND (:endYear IS NULL OR (m.yearNumber < :endYear OR (m.yearNumber = :endYear AND (:endMonth IS NULL OR m.monthNumber <= :endMonth))))")

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyRepository.java
@@ -2,9 +2,15 @@ package com.be3c.sysmetic.domain.strategy.repository;
 
 import com.be3c.sysmetic.domain.strategy.entity.Strategy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface StrategyRepository extends JpaRepository<Strategy, Long> {
     boolean existsByName(String name); // 전략명 중복 확인
+
+    @Query("SELECT s FROM Strategy s WHERE s.statusCode = 'PUBLIC'")
+    List<Strategy> findAllByPublicStatus();
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyRepository.java
@@ -1,6 +1,7 @@
 package com.be3c.sysmetic.domain.strategy.repository;
 
 import com.be3c.sysmetic.domain.strategy.entity.Strategy;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,8 @@ public interface StrategyRepository extends JpaRepository<Strategy, Long> {
 
     @Query("SELECT s FROM Strategy s WHERE s.statusCode = 'PUBLIC'")
     List<Strategy> findAllByPublicStatus();
+
+    // 전략 비공개 상태로 변환
+    @Query("UPDATE Strategy s SET s.statusCode = 'PRIVATE' WHERE s.id = :strategyId")
+    int updateStatusToPrivate(@Param("strategyId") Long strategyId);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyRepository.java
@@ -10,7 +10,8 @@ import java.util.List;
 
 @Repository
 public interface StrategyRepository extends JpaRepository<Strategy, Long> {
-    boolean existsByName(String name); // 전략명 중복 확인
+    // 전략명 중복 확인
+    boolean existsByName(String name);
 
     @Query("SELECT s FROM Strategy s WHERE s.statusCode = 'PUBLIC'")
     List<Strategy> findAllByPublicStatus();

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyStatisticsRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyStatisticsRepository.java
@@ -1,0 +1,10 @@
+package com.be3c.sysmetic.domain.strategy.repository;
+
+import com.be3c.sysmetic.domain.strategy.entity.StrategyStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StrategyStatisticsRepository extends JpaRepository<StrategyStatistics, Long> {
+    StrategyStatistics findByStrategyId(Long strategyId);
+}

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyStatisticsRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyStatisticsRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StrategyStatisticsRepository extends JpaRepository<StrategyStatistics, Long> {
     StrategyStatistics findByStrategyId(Long strategyId);
+    void deleteByStrategyId(Long strategyId);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/StrategyStatisticsService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/StrategyStatisticsService.java
@@ -1,0 +1,4 @@
+package com.be3c.sysmetic.domain.strategy.service;
+
+public interface StrategyStatisticsService {
+}

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/StrategyStatisticsServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/StrategyStatisticsServiceImpl.java
@@ -1,0 +1,341 @@
+package com.be3c.sysmetic.domain.strategy.service;
+
+import com.be3c.sysmetic.domain.strategy.dto.StrategyStatisticsResponseDto;
+import com.be3c.sysmetic.domain.strategy.entity.Daily;
+import com.be3c.sysmetic.domain.strategy.entity.Strategy;
+import com.be3c.sysmetic.domain.strategy.entity.StrategyStatistics;
+import com.be3c.sysmetic.domain.strategy.exception.StrategyBadRequestException;
+import com.be3c.sysmetic.domain.strategy.exception.StrategyExceptionMessage;
+import com.be3c.sysmetic.domain.strategy.repository.DailyRepository;
+import com.be3c.sysmetic.domain.strategy.repository.StrategyRepository;
+import com.be3c.sysmetic.domain.strategy.repository.StrategyStatisticsRepository;
+import com.be3c.sysmetic.global.util.doublehandler.DoubleHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+@Service
+@RequiredArgsConstructor(onConstructor_ = @__(@Autowired))
+public class StrategyStatisticsServiceImpl implements StrategyStatisticsService {
+
+    /*
+    공개 상태인 전략만 계산
+
+    일간분석 데이터 없는 경우 고려 -> 예외 처리할지, 모두 0으로 저장할지 고민 todo 리팩토링
+    일간분석 데이터 존재하는 경우 - date로 정렬
+     */
+
+    private final DoubleHandler doubleHandler;
+    private final DailyRepository dailyRepository;
+    private final StrategyStatisticsRepository strategyStatisticsRepository;
+    private final StrategyRepository strategyRepository;
+
+    // 전략통계 DB 저장 - SchedulerConfiguration 에서 호출하는 메서드
+    public void runStrategyStatistics(Long strategyId) {
+
+        // 최근 일간분석데이터 조회
+        final Daily recentDaily = dailyRepository.findTopByStrategyIdOrderByDateDesc(strategyId);
+
+        // 최근 통계 조회
+        final StrategyStatistics savedStatistics = strategyStatisticsRepository.findByStrategyId(strategyId);
+
+        // 다회 사용시 여러번 조회하지 않도록 저장하여 사용
+        final Daily firstDaily = dailyRepository.findTopByStrategyIdOrderByDateAsc(strategyId);
+        final Daily lastDaily = dailyRepository.findTopByStrategyIdOrderByDateDesc(strategyId);
+
+        final Double accumulatedProfitLossAmount = getAccumulatedProfitLossAmount(recentDaily, strategyId);
+        final Double accumulatedProfitLossRate = getAccumulatedProfitLossRate(recentDaily);
+
+        final Double maxAccumulatedProfitLossAmount = getMaximumAccumulatedProfitLossAmount(savedStatistics, accumulatedProfitLossAmount);
+        final Double currentCapitalReductionAmount = getCurrentCapitalReductionAmount(recentDaily, accumulatedProfitLossAmount, maxAccumulatedProfitLossAmount);
+        final Double currentCapitalReductionRate = getCurrentCapitalReductionRate(strategyId, recentDaily);
+        final Double maximumCapitalReductionAmount = getMaximumCapitalReductionAmount(savedStatistics, currentCapitalReductionAmount);
+
+        final Long totalTradingDays = dailyRepository.countByStrategyId(strategyId);
+        final Long totalProfitDays = getTotalProfitDays(strategyId, recentDaily);
+
+        final StrategyStatistics saveStatistics = StrategyStatistics.builder()
+                .id(savedStatistics != null ? savedStatistics.getId() : null)
+                .strategy(findStrategyById(strategyId))
+                .currentBalance(getBalance(recentDaily))
+                .principal(getPrincipal(recentDaily))
+                .accumulatedDepositWithdrawalAmount(getAccumulatedDepositWithdrawalAmount(recentDaily, strategyId))
+                .accumulatedProfitLossAmount(accumulatedProfitLossAmount)
+                .accumulatedProfitLossRate(accumulatedProfitLossRate)
+                .maximumAccumulatedProfitLossAmount(maxAccumulatedProfitLossAmount)
+                .maximumAccumulatedProfitLossRate(getMaximumAccumulatedProfitLossRate(savedStatistics, accumulatedProfitLossRate))
+                .currentCapitalReductionAmount(currentCapitalReductionAmount)
+                .currentCapitalReductionRate(currentCapitalReductionRate)
+                .maximumCapitalReductionAmount(maximumCapitalReductionAmount)
+                .maximumCapitalReductionRate(getMaximumCapitalReductionRate(savedStatistics, currentCapitalReductionRate))
+                .averageProfitLossAmount(getAverageProfitLossAmount(totalTradingDays, accumulatedProfitLossAmount))
+                .averageProfitLossRate(getAverageProfitLossRate(totalTradingDays, accumulatedProfitLossRate))
+                .maximumDailyProfitAmount(getMaximumProfitAmount(strategyId, recentDaily))
+                .maximumDailyProfitRate(getMaximumProfitRate(strategyId, recentDaily))
+                .maximumDailyLossAmount(getMaximumLossAmount(strategyId, recentDaily))
+                .maximumDailyLossRate(getMaximumLossRate(strategyId, recentDaily))
+                .totalTradingDays(totalTradingDays)
+                .currentContinuousProfitLossDays(getContinuousProfitLossDays(strategyId, recentDaily))
+                .totalProfitDays(totalProfitDays)
+                .maximumContinuousProfitDays(getMaxContinuousProfitDays(strategyId, recentDaily))
+                .totalLossDays(getTotalLossDays(strategyId, recentDaily))
+                .maximumContinuousLossDays(getMaxContinuousLossDays(strategyId, recentDaily))
+                .winningRate(getWinningRate(recentDaily, totalProfitDays, totalTradingDays))
+                .highPointRenewalProgress(getHighPointRenewalProgress(strategyId, recentDaily))
+                .profitFactor(getProfitFactor(strategyId, recentDaily))
+                .roa(getRoa(recentDaily, accumulatedProfitLossAmount, maximumCapitalReductionAmount))
+                .firstRegistrationDate(firstDaily.getDate())
+                .lastRegistrationDate(lastDaily.getDate())
+                .build();
+
+        // DB 저장
+        strategyStatisticsRepository.save(saveStatistics);
+
+    }
+
+    // 전략통계 조회
+    public StrategyStatisticsResponseDto findStrategyStatistics(Long strategyId) {
+        StrategyStatistics statistics = strategyStatisticsRepository.findByStrategyId(strategyId);
+        return StrategyStatisticsResponseDto.builder()
+                .currentBalance(statistics.getCurrentBalance())
+                .accumulatedDepositWithdrawalAmount(statistics.getAccumulatedDepositWithdrawalAmount())
+                .principal(statistics.getPrincipal())
+                .operationPeriod(calculateOperationPeriod(statistics.getFirstRegistrationDate().toLocalDate(), statistics.getLastRegistrationDate().toLocalDate()))
+                .startDate(statistics.getFirstRegistrationDate().toLocalDate())
+                .endDate(statistics.getLastRegistrationDate().toLocalDate())
+                .accumulatedProfitLossAmount(statistics.getAccumulatedProfitLossAmount())
+                .accumulatedProfitLossRate(statistics.getAccumulatedProfitLossRate())
+                .maximumAccumulatedProfitLossAmount(statistics.getMaximumAccumulatedProfitLossAmount())
+                .maximumAccumulatedProfitLossRate(statistics.getMaximumAccumulatedProfitLossRate())
+                .currentCapitalReductionAmount(statistics.getCurrentCapitalReductionAmount())
+                .currentCapitalReductionRate(statistics.getCurrentCapitalReductionRate())
+                .maximumCapitalReductionAmount(statistics.getMaximumCapitalReductionAmount())
+                .maximumCapitalReductionRate(statistics.getMaximumCapitalReductionRate())
+                .averageProfitLossAmount(statistics.getAverageProfitLossAmount())
+                .averageProfitLossRate(statistics.getAverageProfitLossRate())
+                .maximumDailyProfitAmount(statistics.getMaximumDailyProfitAmount())
+                .maximumDailyProfitRate(statistics.getMaximumDailyProfitRate())
+                .maximumDailyLossAmount(statistics.getMaximumDailyLossAmount())
+                .maximumDailyLossRate(statistics.getMaximumDailyLossRate())
+                .totalTradingDays(statistics.getTotalTradingDays())
+                .totalProfitDays(statistics.getTotalProfitDays())
+                .totalLossDays(statistics.getTotalLossDays())
+                .currentContinuousProfitLossDays(statistics.getCurrentContinuousProfitLossDays())
+                .maxContinuousProfitDays(statistics.getMaximumContinuousProfitDays())
+                .maxContinuousLossDays(statistics.getMaximumContinuousLossDays())
+                .winningRate(statistics.getWinningRate())
+                .profitFactor(statistics.getProfitFactor())
+                .roa(statistics.getRoa())
+                .highPointRenewalProgress(statistics.getHighPointRenewalProgress())
+                .build();
+    }
+
+    // find strategy by id
+    private Strategy findStrategyById(Long strategyId) {
+        return strategyRepository.findById(strategyId).orElseThrow(() -> new StrategyBadRequestException(StrategyExceptionMessage.DATA_NOT_FOUND.getMessage()));
+    }
+
+    // 잔고 -> 가장 최근 일간분석 데이터의 잔고
+    private Double getBalance(Daily recentDaily) {
+        return recentDaily == null ? 0.0 : recentDaily.getCurrentBalance();
+    }
+
+    // 원금 -> 가장 최근 일간분석 데이터의 원금
+    private Double getPrincipal(Daily recentDaily) {
+        return recentDaily == null ? 0.0 : recentDaily.getPrincipal();
+    }
+
+    // 누적입출금액 -> 일간분석 데이터의 입출금액 총합
+    // 시스메틱에서 제공한 자료에서는 첫 입금은 계산하지 않음. 반영 필요한가? todo
+    private Double getAccumulatedDepositWithdrawalAmount(Daily recentDaily, Long strategyId) {
+        return recentDaily == null ? 0.0 : dailyRepository.findTotalDepositWithdrawalAmountByStrategyId(strategyId);
+    }
+
+    // 누적손익금액
+    private Double getAccumulatedProfitLossAmount(Daily recentDaily, Long strategyId) {
+        return recentDaily == null ? 0.0 : dailyRepository.findTotalProfitLossAmountByStrategyId(strategyId);
+    }
+
+    // 누적손익률 -> 기준가 / 1000 - 1
+    private Double getAccumulatedProfitLossRate(Daily recentDaily) {
+        return recentDaily == null ? 0.0 : doubleHandler.cutDouble(recentDaily.getStandardAmount() / 1000 - 1);
+    }
+
+    // 최대누적손익금액
+    private Double getMaximumAccumulatedProfitLossAmount(StrategyStatistics savedStatistics, Double accumulatedProfitLossAmount) {
+        if(savedStatistics == null) return accumulatedProfitLossAmount;
+
+        Double savedMaxValue = savedStatistics.getMaximumAccumulatedProfitLossAmount();
+        return Math.max(savedMaxValue, accumulatedProfitLossAmount);
+    }
+
+    // 최대누적손익률
+    private Double getMaximumAccumulatedProfitLossRate(StrategyStatistics savedStatistics, Double accumulatedProfitLossRate) {
+        if(savedStatistics == null) return accumulatedProfitLossRate;
+
+        Double savedMaxValue = savedStatistics.getMaximumAccumulatedProfitLossRate();
+        return Math.max(savedMaxValue, accumulatedProfitLossRate);
+    }
+
+    // 현재자본인하금액 -> 누적손익 > 0 ? 누적손익 - 최대누적손익 : 0
+    private Double getCurrentCapitalReductionAmount(Daily recentDaily, Double accumulatedProfitLossAmount, Double maxAccumulatedProfitLossAmount) {
+        if(recentDaily == null) return 0.0;
+
+        return accumulatedProfitLossAmount > 0 ? accumulatedProfitLossAmount - maxAccumulatedProfitLossAmount : 0;
+    }
+
+    // 현재자본인하율 -> 기준가 - 1000 > 0 ? (기준가 - 최대 기준가) / 기준가 : 0
+    private double getCurrentCapitalReductionRate(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0.0;
+
+        Double standardAmount = recentDaily.getStandardAmount();
+        Double maxStandardAmount = dailyRepository.findTopByStrategyIdOrderByStandardAmountDesc(strategyId).getStandardAmount();
+
+        if(standardAmount == null || standardAmount == 0) return 0.0;
+
+        return standardAmount - 1000 > 0 ? doubleHandler.cutDouble((standardAmount - maxStandardAmount) / standardAmount * 100) : 0.0;
+    }
+
+    // 최대자본인하금액
+    private Double getMaximumCapitalReductionAmount(StrategyStatistics savedStatistics, Double currentCapitalReductionAmount) {
+        if(savedStatistics == null) return currentCapitalReductionAmount;
+
+        return Math.max(savedStatistics.getMaximumCapitalReductionAmount(), currentCapitalReductionAmount);
+    }
+
+    // 최대자본인하율
+    private Double getMaximumCapitalReductionRate(StrategyStatistics savedStatistics, Double currentCapitalReductionRate) {
+        if(savedStatistics == null) return currentCapitalReductionRate;
+
+        return Math.max(savedStatistics.getMaximumCapitalReductionRate(), currentCapitalReductionRate);
+    }
+
+    // 평균손익금 -> 누적손익금액 / 일간분석 개수(=매매일수)
+    private Double getAverageProfitLossAmount(Long totalTradingDays, Double accumulatedProfitLossAmount) {
+        if(totalTradingDays == null || totalTradingDays == 0L) return 0.0;
+
+        return doubleHandler.cutDouble(accumulatedProfitLossAmount / totalTradingDays);
+    }
+
+    // 평균손익률 -> 누적손익율 / 일간분석 개수(=매매일수)
+    private Double getAverageProfitLossRate(Long totalTradingDays, Double averageProfitLossRate) {
+        if(totalTradingDays == null || totalTradingDays == 0L) return 0.0;
+
+        return doubleHandler.cutDouble(averageProfitLossRate / totalTradingDays * 100);
+    }
+
+    // 최대일이익금
+    private Double getMaximumProfitAmount(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0.0;
+
+        return dailyRepository.findTopByStrategyIdOrderByProfitLossAmountDesc(strategyId).getProfitLossAmount();
+    }
+
+    // 최대일이익률
+    private Double getMaximumProfitRate(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0.0;
+
+        return dailyRepository.findTopByStrategyIdOrderByProfitLossRateDesc(strategyId).getProfitLossRate();
+    }
+
+    // 최대일손실금
+    private Double getMaximumLossAmount(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0.0;
+
+        return dailyRepository.findTopByStrategyIdOrderByProfitLossAmountAsc(strategyId).getProfitLossAmount();
+    }
+
+    // 최대일손실률
+    private Double getMaximumLossRate(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0.0;
+
+        return dailyRepository.findTopByStrategyIdOrderByProfitLossRateAsc(strategyId).getProfitLossRate();
+    }
+
+    // 현재연속손익일수
+    private Long getContinuousProfitLossDays(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0L;
+
+        return dailyRepository.findContinuousProfitLossDays(strategyId);
+    }
+
+    // 총이익일수
+    private Long getTotalProfitDays(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0L;
+
+        return dailyRepository.countProfitDays(strategyId);
+    }
+
+    // 최대연속이익일수
+    private Long getMaxContinuousProfitDays(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0L;
+
+        Long maxConsecutiveProfitDays = dailyRepository.findMaxConsecutiveProfitDays(strategyId);
+        return maxConsecutiveProfitDays != null ? maxConsecutiveProfitDays : 0L;
+    }
+
+    // 총손실일수
+    private Long getTotalLossDays(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0L;
+
+        return dailyRepository.countLossDays(strategyId);
+    }
+
+    // 최대연속손실일수
+    private Long getMaxContinuousLossDays(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0L;
+
+        Long maxConsecutiveLossDays = dailyRepository.findMaxConsecutiveLossDays(strategyId);
+        return maxConsecutiveLossDays != null ? maxConsecutiveLossDays : 0L;
+    }
+
+    // 승률 -> 이익일수 / 거래일수
+    private Double getWinningRate(Daily recentDaily, Long totalProfitDays, Long totalTradingDays) {
+        if(recentDaily == null || totalTradingDays == 0L) return 0.0;
+
+        return doubleHandler.cutDouble((double) (totalProfitDays / totalTradingDays));
+    }
+
+    // 고점갱신 후 경과일
+    private Long getHighPointRenewalProgress(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0L;
+
+        return dailyRepository.findHighPointRenewalProgress(strategyId);
+    }
+
+    // profit factor -> 총손실금액 < 0 ? 총이익금액 / |총손실금액| : 0
+    private Double getProfitFactor(Long strategyId, Daily recentDaily) {
+        if(recentDaily == null) return 0.0;
+
+        Double totalProfitAmount = dailyRepository.findTotalProfitAmountByStrategyId(strategyId);
+        Double totalLossAmount = dailyRepository.findTotalLossAmountByStrategyId(strategyId);
+
+        if(totalProfitAmount == null || totalLossAmount == null || totalLossAmount == 0) return 0.0;
+
+        return totalLossAmount < 0 ? doubleHandler.cutDouble(totalProfitAmount / (totalLossAmount * -1)) : 0.0;
+    }
+
+    // roa -> 누적손익금 / 최대자본인하금액 * -1
+    private Double getRoa(Daily recentDaily, Double accumulatedProfitLossAmount, Double maximumCapitalReductionAmount) {
+        if(recentDaily == null || maximumCapitalReductionAmount == 0) return 0.0;
+
+        return doubleHandler.cutDouble(accumulatedProfitLossAmount / maximumCapitalReductionAmount * -1);
+    }
+
+
+    // 운용기간 -> 첫번째 일간분석 데이터의 등록일시, 마지막 일간분석 데이터의 등록일시 차이 - m년 n개월
+    private String calculateOperationPeriod(LocalDate startDate, LocalDate endDate) {
+        Period period = Period.between(startDate, endDate);
+        int years = period.getYears();
+        int months = period.getMonths();
+
+        if(years == 0 && months == 0) return "0년 0개월";
+
+        if(years == 0) return "0년 " + months + "개월";
+
+        return years + "년 " + months + "개월";
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

전략 통계 계산 및 조회

## #️⃣ 연관된 이슈

#48 

## 📋 작업 내용

- 일간분석 데이터에 따른 전략 통계 계산 - 매일 자정에 진행하도록 스케쥴러 구현
- 일간분석 데이터 삭제시 전략 통계 삭제 (리팩토링시 다른 방향으로 구현 필요)
- 전략 통계 조회
