### PR TITLE
update: 프론트 토큰 유효성 확인용 API 및 토큰 수정

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/AccountController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/AccountController.java
@@ -76,9 +76,6 @@ public class AccountController {
     )
     @PostMapping("/auth/reset-password")
     public ResponseEntity<APIResponse<String>> resetPassword(@Valid @RequestBody ResetPasswordRequestDto requestDto, HttpServletRequest request) {
-        if(!accountService.isAuthCodeMatch(requestDto.getEmail(), requestDto.getEmailAuthCode())){
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(APIResponse.fail(ErrorCode.BAD_REQUEST, "이메일 인증코드 불일치"));
-        }
         if(!accountService.isPasswordMatch(requestDto.getPassword(), requestDto.getRewritePassword())) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(APIResponse.fail(ErrorCode.BAD_REQUEST, "비밀번호 불일치"));
         }

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
@@ -1,26 +1,80 @@
 package com.be3c.sysmetic.domain.member.controller;
 
+import com.be3c.sysmetic.domain.member.dto.TokenApiResponseDto;
+import com.be3c.sysmetic.domain.member.entity.Member;
+import com.be3c.sysmetic.domain.member.repository.MemberRepository;
 import com.be3c.sysmetic.global.common.response.APIResponse;
+import com.be3c.sysmetic.global.config.security.JwtTokenProvider;
+import com.be3c.sysmetic.global.util.file.dto.FileReferenceType;
+import com.be3c.sysmetic.global.util.file.dto.FileRequestDto;
+import com.be3c.sysmetic.global.util.file.service.FileService;
+import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
+
 @Tag(name = "토큰 유효성 확인 API", description = "로그인 상태 확인용")
+@Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/v1")
 public class TokenController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final FileService fileService;
 
     @Operation(
             summary = "토큰 유효성 확인 API",
             description = "로그인 상태 확인용"
     )
     @GetMapping("/auth")
-    public ResponseEntity<APIResponse> checkToken() {
-        return ResponseEntity.status(HttpStatus.OK).body(APIResponse.success());
+    public ResponseEntity<APIResponse<TokenApiResponseDto>> checkToken(HttpServletRequest request) {
+
+        // Access 토큰 추출
+        String accessToken = jwtTokenProvider.extractToken(request);
+        if(accessToken == null) {
+            return ResponseEntity.status(HttpStatus.OK).body(APIResponse.success());
+        }
+        // 토큰에서 회원id 추출
+        Claims claims = jwtTokenProvider.parseTokenClaims(accessToken);
+        Long memberId = claims.get("memberId", Long.class);
+
+        // 회원id를 통해서 Member 추출
+        Optional<Member> member = memberRepository.findById(memberId);
+
+        // roleCode("RC001"방식) 를 Role("USER"방식) 로 명칭 변환
+        String role = jwtTokenProvider.roleCodeChangeRole(member.get().getRoleCode());
+
+        // 프로필 이미지 경로 추출
+        String profileImage = null;
+        try {
+            profileImage = fileService.getFilePath(new FileRequestDto(FileReferenceType.MEMBER, memberId));
+        } catch (EntityNotFoundException e) {
+            log.info("프로필 이미지 추출 실패");
+        }
+
+        // 응답 객체에 회원 정보 넣기 (memberId, roleCode, email, nickname, profileImage)
+        TokenApiResponseDto dto = TokenApiResponseDto.builder()
+                .memberId(memberId)
+                .roleCode(role)
+                .email(member.get().getEmail())
+                .nickname(member.get().getNickname())
+                .profileImage(profileImage)
+                .build();
+
+        // 회원 정보 반환
+        return ResponseEntity.status(HttpStatus.OK).body(APIResponse.success(dto));
     }
 
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/ResetPasswordRequestDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/ResetPasswordRequestDto.java
@@ -27,9 +27,4 @@ public class ResetPasswordRequestDto {
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{6,20}$", message = "비밀번호는 영문자(대, 소문자), 숫자, 특수문자를 포함하여 6~20자로 입력해야 합니다.")
     @JsonProperty("rewritePassword")
     private String rewritePassword; // 새로운 비밀번호 재입력
-
-    @NotNull
-    @Pattern(regexp = "^\\d{6}$", message = "인증 코드는 6자리의 숫자입니다.")
-    private String emailAuthCode;
-
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/TokenApiResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/TokenApiResponseDto.java
@@ -1,0 +1,18 @@
+package com.be3c.sysmetic.domain.member.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenApiResponseDto {
+
+    private Long memberId;
+    private String roleCode;
+    private String email;
+    private String nickname;
+    private String profileImage;
+
+}

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/MemberRepository.java
@@ -2,7 +2,6 @@ package com.be3c.sysmetic.domain.member.repository;
 
 import com.be3c.sysmetic.domain.member.dto.MemberGetResponseDto;
 import com.be3c.sysmetic.domain.member.entity.Member;
-import com.be3c.sysmetic.domain.member.entity.MemberSearchRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/AccountService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/AccountService.java
@@ -12,7 +12,4 @@ public interface AccountService {
 
     // 6. 비밀번호 재설정
     boolean resetPassword(String email, String password);
-
-    // 이메일 인증 코드 확인
-    boolean isAuthCodeMatch(String email, String authCode);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/AccountServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/AccountServiceImpl.java
@@ -29,7 +29,6 @@ public class AccountServiceImpl implements AccountService {
      */
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
-    private final RedisUtils redisUtils;
 
     // 1. 이메일 반환 메서드
     @Override
@@ -52,14 +51,6 @@ public class AccountServiceImpl implements AccountService {
     // 5. 비밀번호 일치 여부 확인
     public boolean isPasswordMatch(String password, String rewritePassword) {
         return Objects.equals(password, rewritePassword);
-    }
-
-    // 이메일 인증 코드 발송 : RegisterService 이용 중
-    // 이메일 인증 코드 일치 여부 확인
-    @Override
-    public boolean isAuthCodeMatch(String email, String authCode){
-
-        return redisUtils.getEmailAuthCode(email).equals(authCode);
     }
 
     // 6. 비밀번호 재설정

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/LoginServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/LoginServiceImpl.java
@@ -100,12 +100,12 @@ public class LoginServiceImpl implements LoginService {
         }
 
         // 토큰 생성
-        String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail(), member.getRoleCode(), member.getNickname(), memberProfileImage);
+        String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail(), member.getRoleCode());
         String refreshToken = null;
         if(rememberMe) {
-            refreshToken = jwtTokenProvider.generateMonthRefreshToken(member.getId(), member.getEmail(), member.getRoleCode(), member.getNickname(), memberProfileImage);
+            refreshToken = jwtTokenProvider.generateMonthRefreshToken(member.getId(), member.getEmail(), member.getRoleCode());
         } else {
-            refreshToken = jwtTokenProvider.generateHourRefreshToken(member.getId(), member.getEmail(), member.getRoleCode(), member.getNickname(), memberProfileImage);
+            refreshToken = jwtTokenProvider.generateHourRefreshToken(member.getId(), member.getEmail(), member.getRoleCode());
         }
 
         Map<String, String> tokenMap = new HashMap<>();

--- a/src/main/java/com/be3c/sysmetic/global/config/security/CustomUserDetails.java
+++ b/src/main/java/com/be3c/sysmetic/global/config/security/CustomUserDetails.java
@@ -16,8 +16,6 @@ public class CustomUserDetails implements UserDetails {
     private Long memberId;
     private String role;
     private String email;
-    private String nickname;
-    private String password;
     private Collection<? extends GrantedAuthority> authorities;
 
     @Override

--- a/src/main/java/com/be3c/sysmetic/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/be3c/sysmetic/global/config/security/JwtAuthenticationFilter.java
@@ -84,14 +84,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Long memberId = claims.get("memberId", Long.class);
             String role = claims.get("role", String.class);
             String email = claims.get("email", String.class);
-            String nickname = claims.get("nickname", String.class);
-            String profileImage = claims.get("profileImage", String.class);
 
             // 4-1. role을 GrantedAuthority로 변환하여 authorities 리스트 생성
             List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
             // 4-2. UserDetails 객체 생성
-            UserDetails userDetails = new CustomUserDetails(memberId, role, email, nickname, profileImage, authorities);
+            UserDetails userDetails = new CustomUserDetails(memberId, role, email, authorities);
 
             // 5. SecurityContext에 authentication 저장
             Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
@@ -102,7 +100,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        // Access 토큰이 만료된 경우
+        // 2.2 Access 토큰이 만료된 경우
         // true-재발급 필요O (재발급 메서드 진행) , false - 재발급 필요X (다음 필터로 전달)
         if(jwtTokenProvider.needsReissueToken(accessToken)) {
             Map<String,String> tokenMap = jwtTokenProvider.reissueToken(accessToken); // 재발급 메서드
@@ -128,14 +126,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Long memberId = claims.get("memberId", Long.class);
             String role = claims.get("role", String.class);
             String email = claims.get("email", String.class);
-            String nickname = claims.get("nickname", String.class);
-            String profileImage = claims.get("profileImage", String.class);
 
             // 4-1. role을 GrantedAuthority로 변환하여 authorities 리스트 생성
             List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
             // 4-2. UserDetails 객체 생성
-            UserDetails userDetails = new CustomUserDetails(memberId, role, email, nickname, profileImage, authorities);
+            UserDetails userDetails = new CustomUserDetails(memberId, role, email, authorities);
 
             // 5. SecurityContext에 authentication 저장
             Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, authorities);

--- a/src/main/java/com/be3c/sysmetic/global/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/be3c/sysmetic/global/config/security/JwtTokenProvider.java
@@ -49,7 +49,7 @@ public class JwtTokenProvider {
     private long HOUR_REFRESH_TOKEN_EXPIRE_TIME;     // 1시간
 
     // 1. Token 생성 메서드
-    public String generateToken(Long memberId, String email, String roleCode, String nickname, String profileImage, long expiration) {
+    public String generateToken(Long memberId, String email, String roleCode, long expiration) {
         String role = null;
         if (roleCode.startsWith("RC")) {
             // "RC"로 시작하는 경우, roleCode를 role로 변경
@@ -64,8 +64,6 @@ public class JwtTokenProvider {
                 .claim("memberId", memberId)
                 .claim("email", email)
                 .claim("role", role)
-                .claim("nickname", nickname)
-                .claim("profileImage", profileImage)
                 .issuedAt(now)
                 .expiration(tokenExpires)
                 .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
@@ -73,18 +71,18 @@ public class JwtTokenProvider {
     }
 
     // 2. Access Token 생성 메서드
-    public String generateAccessToken(Long memberId, String email, String roleCode, String nickname, String profileImage) {
-        return generateToken(memberId, email, roleCode, nickname, profileImage, ACCESS_TOKEN_EXPIRE_TIME);
+    public String generateAccessToken(Long memberId, String email, String roleCode) {
+        return generateToken(memberId, email, roleCode, ACCESS_TOKEN_EXPIRE_TIME);
     }
 
     // 3. Refresh Token (Month) 생성 메서드
-    public String generateMonthRefreshToken(Long memberId, String email, String roleCode, String nickname, String profileImage) {
-        return generateToken(memberId, email, roleCode, nickname, profileImage, MONTH_REFRESH_TOKEN_EXPIRE_TIME);
+    public String generateMonthRefreshToken(Long memberId, String email, String roleCode) {
+        return generateToken(memberId, email, roleCode, MONTH_REFRESH_TOKEN_EXPIRE_TIME);
     }
 
     // 0. Refresh Token (Hour) 생성 메서드
-    public String generateHourRefreshToken(Long memberId, String email, String roleCode, String nickname, String profileImage) {
-        return generateToken(memberId, email, roleCode, nickname, profileImage, HOUR_REFRESH_TOKEN_EXPIRE_TIME);
+    public String generateHourRefreshToken(Long memberId, String email, String roleCode) {
+        return generateToken(memberId, email, roleCode, HOUR_REFRESH_TOKEN_EXPIRE_TIME);
     }
 
     // 4. 토큰 유효성 검증 메서드
@@ -183,11 +181,9 @@ public class JwtTokenProvider {
         Long memberId = Long.valueOf(String.valueOf(claims.get("memberId")));
         String email = (String) claims.get("email");
         String role = (String) claims.get("role");
-        String nickname = (String) claims.get("nickname");
-        String profileImage = (String) claims.get("profileImage");
 
-        String accessToken = generateAccessToken(memberId, email, role, nickname, profileImage);
-        String refreshToken = generateMonthRefreshToken(memberId, email, role, nickname, profileImage);
+        String accessToken = generateAccessToken(memberId, email, role);
+        String refreshToken = generateMonthRefreshToken(memberId, email, role);
         tokenMap.put("accessToken", accessToken);
         tokenMap.put("refreshToken", refreshToken);
 

--- a/src/test/java/com/be3c/sysmetic/domain/member/controller/AccountControllerTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/controller/AccountControllerTest.java
@@ -71,7 +71,7 @@ class AccountControllerTest {
         );
 
         // 1. 성공
-        mockMvc.perform(post("/auth/find-email")
+        mockMvc.perform(post("/v1/auth/find-email")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -84,7 +84,7 @@ class AccountControllerTest {
         requestBody = String.format(
                 "{\"name\":\"%s\", \"phoneNumber\":\"%s\"}", name, phoneNumber
         );
-        mockMvc.perform(post("/auth/find-email")
+        mockMvc.perform(post("/v1/auth/find-email")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -96,7 +96,7 @@ class AccountControllerTest {
         requestBody = String.format(
                 "{\"name\":\"%s\", \"phoneNumber\":\"%s\"}", name, phoneNumber
         );
-        mockMvc.perform(post("/auth/find-email")
+        mockMvc.perform(post("/v1/auth/find-email")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -108,7 +108,7 @@ class AccountControllerTest {
         requestBody = String.format(
                 "{\"name\":\"%s\", \"phoneNumber\":\"%s\"}", name, phoneNumber
         );
-        mockMvc.perform(post("/auth/find-email")
+        mockMvc.perform(post("/v1/auth/find-email")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -120,18 +120,18 @@ class AccountControllerTest {
     @DisplayName("이메일 확인 및 인증코드 발송 테스트")
     void checkEmailAndSendCodeTest() throws Exception {
         // 1. 성공
-        mockMvc.perform(get("/auth/reset-password")
+        mockMvc.perform(get("/v1/auth/reset-password")
                         .param("email", "test1@test.com"))
                 .andExpect(status().isOk());
 
         // 2. 실패 - 이메일 형식 불일치
-        mockMvc.perform(get("/auth/reset-password")
+        mockMvc.perform(get("/v1/auth/reset-password")
                         .param("email", "invalid-email"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("유효하지 않은 값입니다."));
 
         // 3. 실패 - 존재하지 않는 이메일
-        mockMvc.perform(get("/auth/reset-password")
+        mockMvc.perform(get("/v1/auth/reset-password")
                         .param("email", "nonexist@example.com"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("잘못된 형식 또는 누락된 데이터가 있습니다."));
@@ -150,7 +150,7 @@ class AccountControllerTest {
                 , email, password, rewritePassword
         );
 
-        mockMvc.perform(post("/auth/reset-password")
+        mockMvc.perform(post("/v1/auth/reset-password")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -164,7 +164,7 @@ class AccountControllerTest {
                 , email, wrongPassword, rewritePassword
         );
 
-        mockMvc.perform(post("/auth/reset-password")
+        mockMvc.perform(post("/v1/auth/reset-password")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -179,7 +179,7 @@ class AccountControllerTest {
                 , email, unMatchedPassword, rewritePassword
         );
 
-        mockMvc.perform(post("/auth/reset-password")
+        mockMvc.perform(post("/v1/auth/reset-password")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -194,7 +194,7 @@ class AccountControllerTest {
                 , nonExistEmail, password, rewritePassword
         );
 
-        mockMvc.perform(post("/auth/reset-password")
+        mockMvc.perform(post("/v1/auth/reset-password")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/be3c/sysmetic/domain/member/controller/LoginControllerTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/controller/LoginControllerTest.java
@@ -89,7 +89,7 @@ class LoginControllerTest {
                 email, password, rememberMe
         );
 
-        ResultActions resultActions = mockMvc.perform(post("/auth/login")
+        ResultActions resultActions = mockMvc.perform(post("/v1/auth/login")
                         .content(requestBody)   // JSON 데이터를 요청 본문에 추가
                         .contentType(MediaType.APPLICATION_JSON)// 요청 Content-Type을 JSON으로 설정
                         .accept(MediaType.APPLICATION_JSON))    // 응답의 Accept 타입 설정
@@ -124,7 +124,7 @@ class LoginControllerTest {
                 "formatMismatch", password, rememberMe
         );
 
-        ResultActions resultActions = mockMvc.perform(post("/auth/login")
+        ResultActions resultActions = mockMvc.perform(post("/v1/auth/login")
                         .content(invalidEmailRequestBody)  // JSON 본문 데이터 전달
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -136,7 +136,7 @@ class LoginControllerTest {
                 email, "formatMismatch", rememberMe
         );
 
-        resultActions = mockMvc.perform(post("/auth/login")
+        resultActions = mockMvc.perform(post("/v1/auth/login")
                         .content(invalidPasswordRequestBody)  // JSON 본문 데이터 전달
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -148,7 +148,7 @@ class LoginControllerTest {
                 "unregister@test.com", password, rememberMe
         );
 
-        resultActions = mockMvc.perform(post("/auth/login")
+        resultActions = mockMvc.perform(post("/v1/auth/login")
                         .content(unregisterEmailRequestBody)  // JSON 본문 데이터 전달
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -160,7 +160,7 @@ class LoginControllerTest {
                 email, "unMatch123@", rememberMe
         );
 
-        resultActions = mockMvc.perform(post("/auth/login")
+        resultActions = mockMvc.perform(post("/v1/auth/login")
                         .content(unMatchPasswordRequestBody)  // JSON 본문 데이터 전달
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/be3c/sysmetic/domain/member/service/FolderServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/service/FolderServiceTest.java
@@ -93,8 +93,6 @@ public class FolderServiceTest {
                 1L, // memberId
                 "test@example.com", // email
                 "USER", // role
-                "",
-                "",
                 authorities // 권한 목록,
         );
 

--- a/src/test/java/com/be3c/sysmetic/domain/member/service/InterestStrategyServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/service/InterestStrategyServiceTest.java
@@ -171,8 +171,6 @@ public class InterestStrategyServiceTest {
                 1L, // memberId
                 "test@example.com", // email
                 "USER", // role
-                "",
-                "",
                 authorities // 권한 목록
         );
 

--- a/src/test/java/com/be3c/sysmetic/domain/strategy/service/KPRatioCalculateTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/strategy/service/KPRatioCalculateTest.java
@@ -33,7 +33,7 @@ public class KPRatioCalculateTest {
     private final StrategyRepository strategyRepository;
     private final TraderStrategyServiceImpl traderStrategyService;
     private final DailyRepository dailyRepository;
-    private final MonthRepository monthRepository;
+    private final MonthlyRepository monthlyRepository;
     private final DailyServiceImpl dailyServiceImpl;
     private final StrategyStatisticsRepository statisticsRepository;
     private final StrategyStatisticsServiceImpl statisticsService;
@@ -50,7 +50,7 @@ public class KPRatioCalculateTest {
         // delete
         statisticsRepository.deleteAll();
         dailyRepository.deleteAll();
-        monthRepository.deleteAll();
+        monthlyRepository.deleteAll();
         strategyStockReferenceRepository.deleteAll();
         strategyRepository.deleteAll();
     }
@@ -96,7 +96,7 @@ public class KPRatioCalculateTest {
                 .password("sys1234!")
                 .name("한감자")
                 .nickname("감자")
-                .birth(LocalDateTime.now())
+                .birth(LocalDateTime.now().toLocalDate())
                 .phoneNumber("01022223333")
                 .usingStatusCode("")
                 .totalFollow(160)

--- a/src/test/java/com/be3c/sysmetic/domain/strategy/service/ReplyServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/strategy/service/ReplyServiceTest.java
@@ -186,8 +186,6 @@ public class ReplyServiceTest {
                 1L, // memberId
                 "test@example.com", // email
                 "TRADER", // role
-                "",
-                "",
                 authorities // 권한 목록
         );
 

--- a/src/test/java/com/be3c/sysmetic/domain/strategy/service/StrategyApprovalServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/strategy/service/StrategyApprovalServiceTest.java
@@ -186,8 +186,6 @@ public class StrategyApprovalServiceTest {
                 1L, // memberId
                 "test@example.com", // email
                 "TRADER", // role
-                "",
-                "",
                 authorities // 권한 목록
         );
 

--- a/src/test/java/com/be3c/sysmetic/global/config/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/be3c/sysmetic/global/config/security/JwtTokenProviderTest.java
@@ -79,7 +79,7 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("토큰 생성 테스트")
     public void generateTokenTest () {
-        String accessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", "nickname", "image", 30 * 60 * 1000L);
+        String accessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", 30 * 60 * 1000L);
 
         // accessToken을 검증 후 claims 객체 받기
         Claims claims = testMethodTokenParser(accessToken);
@@ -101,7 +101,7 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("Access 토큰 생성 테스트 ")
     public void generateAccessTokenTest () {
-        String accessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN", "nickname", "image" );
+        String accessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN");
         Claims claims = testMethodTokenParser(accessToken);
 
         assertEquals(String.valueOf(001L), claims.get("memberId").toString());
@@ -116,7 +116,7 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("Refresh 토큰 생성 메서드")
     public void generateRefreshTokenTest () {
-        String refreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN", "nickname", "image" );
+        String refreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN");
         Claims claims = testMethodTokenParser(refreshToken);
 
         assertEquals(String.valueOf(001L), claims.get("memberId").toString());
@@ -137,15 +137,15 @@ class JwtTokenProviderTest {
     @DisplayName("토큰 유효성 검증 테스트")
     public void validateToken1Test1() throws InterruptedException {
         // 1) 유효한 토큰
-        String accessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
-        String refreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
+        String accessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN");
+        String refreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN");
         Assertions.assertTrue(jwtTokenProvider.validateToken(accessToken));
         Assertions.assertTrue(jwtTokenProvider.validateToken(refreshToken));
 
         // 2) 만료된 토큰 - 만료일자를 짧게 설정하여 유효한 토큰인지 체크 후 -> 만료되면 만료된 토큰인지 체크
-        accessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", "nickname", "image", 5000);
+        accessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", 5000);
         Assertions.assertTrue(jwtTokenProvider.validateToken(accessToken));
-        refreshToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", "nickname", "image", 5000);
+        refreshToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", 5000);
         Assertions.assertTrue(jwtTokenProvider.validateToken(refreshToken));
 
         Thread.sleep(10000); // 10초 대기
@@ -157,7 +157,7 @@ class JwtTokenProviderTest {
         String invalidToken = "This.is.an.invalid.token";
         Assertions.assertThrows(AuthenticationCredentialsNotFoundException.class, () -> jwtTokenProvider.validateToken(invalidToken));
         // 서명키 위조 (변경된 토큰)
-        String validToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
+        String validToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN");
         String tamperedToken = validToken + "errer";
         Assertions.assertThrows(AuthenticationCredentialsNotFoundException.class, () -> jwtTokenProvider.validateToken(tamperedToken));
         // 비어있는 토큰
@@ -175,10 +175,10 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("재발급 필요 여부 테스트")
     public void validateToken2Test() throws InterruptedException {
-        String validAccessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
-        String validRefreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
-        String invalidAccessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", "nickname", "image", 1);
-        String invalidRefreshToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", "nickname", "image", 1);
+        String validAccessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN");
+        String validRefreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN");
+        String invalidAccessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", 1);
+        String invalidRefreshToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", 1);
 
         // 1) Access 유효, Refresh 유효 => false
         redisUtils.saveToken(validAccessToken, validRefreshToken);
@@ -205,10 +205,10 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("Access/Refresh 토큰 재발급 테스트")
     public void reGenerateToken() throws InterruptedException {
-        String validAccessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
-        String validRefreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
-        String invalidAccessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", "nickname", "image", 1);
-        String invalidRefreshToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", "nickname", "image", 1);
+        String validAccessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN");
+        String validRefreshToken = jwtTokenProvider.generateMonthRefreshToken(001L, "test@gmail.com", "ADMIN");
+        String invalidAccessToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", 1);
+        String invalidRefreshToken = jwtTokenProvider.generateToken(001L, "test@gmail.com", "ADMIN", 1);
 
         // 1) Access 만료, Refresh 유효 => 재발급O
         redisUtils.saveToken(invalidAccessToken, validRefreshToken);
@@ -248,7 +248,7 @@ class JwtTokenProviderTest {
     @DisplayName("Claims 추출 테스트")
     public void parseTokenClaimsTest() {
         // 1) 유효한 토큰인 경우
-        String validAccessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN", "nickname", "image");
+        String validAccessToken = jwtTokenProvider.generateAccessToken(001L, "test@gmail.com", "ADMIN");
         Claims claims = jwtTokenProvider.parseTokenClaims(validAccessToken);
         assertEquals(String.valueOf(001L), claims.get("memberId").toString());
         assertEquals("test@gmail.com", claims.get("email"));


### PR DESCRIPTION
# 🚀 Pull Request

프론트 토큰 유효성 확인용 API 및 토큰 수정

## #️⃣ 연관된 이슈

#108 

## 📋 작업 내용

- 토큰 유효성 확인용 API(TokenController)의 반환값(TokenApiResponseDto) 추가
- 토큰 데이터에서 nickname, profileImage 제외
- 토큰 데이터 수정으로 인한 테스트 코드 에러 처리