### PR TITLE
fix: 토큰 확인용 API 에러 해결

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
@@ -4,9 +4,10 @@ import com.be3c.sysmetic.domain.member.dto.TokenApiResponseDto;
 import com.be3c.sysmetic.domain.member.entity.Member;
 import com.be3c.sysmetic.domain.member.repository.MemberRepository;
 import com.be3c.sysmetic.global.common.response.APIResponse;
+import com.be3c.sysmetic.global.common.response.ErrorCode;
 import com.be3c.sysmetic.global.config.security.JwtTokenProvider;
 import com.be3c.sysmetic.global.util.file.dto.FileReferenceType;
-import com.be3c.sysmetic.global.util.file.dto.FileRequestDto;
+import com.be3c.sysmetic.global.util.file.dto.FileRequest;
 import com.be3c.sysmetic.global.util.file.service.FileService;
 import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,27 +41,27 @@ public class TokenController {
     )
     @GetMapping("/auth")
     public ResponseEntity<APIResponse<TokenApiResponseDto>> checkToken(HttpServletRequest request) {
-
         // Access 토큰 추출
         String accessToken = jwtTokenProvider.extractToken(request);
         if(accessToken == null) {
-            return ResponseEntity.status(HttpStatus.OK).body(APIResponse.success());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(APIResponse.fail(ErrorCode.UNAUTHORIZED, "토큰 미존재 또는 정상적이지 않은 토큰"));
         }
+
         // 토큰에서 회원id 추출
         Claims claims = jwtTokenProvider.parseTokenClaims(accessToken);
         Long memberId = claims.get("memberId", Long.class);
 
         // 회원id를 통해서 Member 추출
-        Optional<Member> member = memberRepository.findById(memberId);
+        Member member = memberRepository.findById(memberId).orElseThrow(EntityNotFoundException::new);
 
         // roleCode("RC001"방식) 를 Role("USER"방식) 로 명칭 변환
-        String role = jwtTokenProvider.roleCodeChangeRole(member.get().getRoleCode());
+        String role = jwtTokenProvider.roleCodeChangeRole(member.getRoleCode());
 
         // 프로필 이미지 경로 추출
         String profileImage = null;
         try {
-            profileImage = fileService.getFilePath(new FileRequestDto(FileReferenceType.MEMBER, memberId));
-        } catch (EntityNotFoundException e) {
+            profileImage = fileService.getFilePath(new FileRequest(FileReferenceType.MEMBER, memberId));
+        } catch (IndexOutOfBoundsException e) {
             log.info("프로필 이미지 추출 실패");
         }
 
@@ -68,8 +69,8 @@ public class TokenController {
         TokenApiResponseDto dto = TokenApiResponseDto.builder()
                 .memberId(memberId)
                 .roleCode(role)
-                .email(member.get().getEmail())
-                .nickname(member.get().getNickname())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
                 .profileImage(profileImage)
                 .build();
 

--- a/src/main/java/com/be3c/sysmetic/global/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/be3c/sysmetic/global/config/security/JwtTokenProvider.java
@@ -136,37 +136,37 @@ public class JwtTokenProvider {
         }
     }
 
-        /* 5. Token 재발급 메서드
-            올바른 토큰이라고 가정
-            1) Access 토큰은 만료O, Refresh 토큰은 만료X 경우
-                - request에 있는 Access 토큰을 서버에서 받는다.
-                - Access 토큰의 만료일자 확인
-                - 1-1) 만료되지 않은 경우
-                    -> 로그인 단계 진행
-                - 1-2) 만료된 경우
-                    - Refresh 토큰의 만료일자 확인
-                        - 1-2-1) 만료된 경우
-                            -> 유효하지 않은 접근으로 처리 (재로그인 안내)
-                        - 1-2-2) 만료되지 않은 경우
-                            -> Access 와 Refresh Token 재발급
-            2) Access 와 Refresh 토큰 모두 만료된 경우
+    /* 5. Token 재발급 메서드
+        올바른 토큰이라고 가정
+        1) Access 토큰은 만료O, Refresh 토큰은 만료X 경우
+            - request에 있는 Access 토큰을 서버에서 받는다.
+            - Access 토큰의 만료일자 확인
+            - 1-1) 만료되지 않은 경우
+                -> 로그인 단계 진행
+            - 1-2) 만료된 경우
+                - Refresh 토큰의 만료일자 확인
+                    - 1-2-1) 만료된 경우
+                        -> 유효하지 않은 접근으로 처리 (재로그인 안내)
+                    - 1-2-2) 만료되지 않은 경우
+                        -> Access 와 Refresh Token 재발급
+        2) Access 와 Refresh 토큰 모두 만료된 경우
 
-            [순서]
-            1. Access 토큰을 받아서 validateToken(token) 메서드로 유효성 검증
-            2. 검증 결과에 따른 처리
-                2-1. 검증 결과 true인 경우 (유효)
-                    -> Access 토큰이 유효하므로, 재발급 진행하지 않고 메서드 종료
-                2-2. 검증 결과가 false인 경우 (만료)
-                    -> 3. refresh 토큰의 유효성 검증
-                2-3. 다른 예외가 발생한 경우
-                    -> 예외 처리
-            3. Refresh 토큰의 만료 여부 확인
-                3-1. 유효한 경우
-                    -> 4. Access 와 Refresh 토큰 재발급
-                3-2. 만료된 경우
-                    -> 재발급 불가능. 예외 발생 (재로그인 유도)
-            4. Access 와 Refresh Token 재발급
-        */
+        [순서]
+        1. Access 토큰을 받아서 validateToken(token) 메서드로 유효성 검증
+        2. 검증 결과에 따른 처리
+            2-1. 검증 결과 true인 경우 (유효)
+                -> Access 토큰이 유효하므로, 재발급 진행하지 않고 메서드 종료
+            2-2. 검증 결과가 false인 경우 (만료)
+                -> 3. refresh 토큰의 유효성 검증
+            2-3. 다른 예외가 발생한 경우
+                -> 예외 처리
+        3. Refresh 토큰의 만료 여부 확인
+            3-1. 유효한 경우
+                -> 4. Access 와 Refresh 토큰 재발급
+            3-2. 만료된 경우
+                -> 재발급 불가능. 예외 발생 (재로그인 유도)
+        4. Access 와 Refresh Token 재발급
+    */
     // 6. Access 와 Refresh Token 재발급 메서드
     public Map<String, String> reissueToken(String token) {
         /*
@@ -194,10 +194,10 @@ public class JwtTokenProvider {
     public Claims parseTokenClaims(String token) {
         try {
             return Jwts.parser()
-                   .verifyWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
-                   .build()
-                   .parseSignedClaims(token)
-                   .getPayload();
+                    .verifyWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
         } catch (ExpiredJwtException e) {
             log.info("만료된 토큰");
             return e.getClaims();
@@ -235,6 +235,10 @@ public class JwtTokenProvider {
         if (roleCode == null || roleCode.isEmpty()) {
             log.info("roleCode가 null이거나 빈 값입니다.");
             throw new IllegalArgumentException("roleCode가 올바르지 않습니다.");
+        }
+
+        if(roleCode.equals("USER") || roleCode.equals("TRADER") || roleCode.equals("MANAGER") || roleCode.equals("ADMIN")) {
+            return roleCode;
         }
 
         return switch (roleCode) {


### PR DESCRIPTION
# 🚀 Pull Request

토큰 확인용 API 에러 해결

## #️⃣ 연관된 이슈

#116

## 📋 작업 내용

- AccessToken 미존재 시 기존 OK 에서 UNAUTHORIZED 반환으로 수정
- TokenController의 IndexOutOfBoundsException, EntityNotFoundException 예외 추가
- JwtTokenProvider의 roleCodeChangeRole 메서드 보완
