### PR TITLE
fix: 프론트 전용 토큰 API 에러 해결

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
@@ -61,7 +61,7 @@ public class TokenController {
         String profileImage = null;
         try {
             profileImage = fileService.getFilePath(new FileRequest(FileReferenceType.MEMBER, memberId));
-        } catch (IndexOutOfBoundsException e) {
+        } catch (IllegalArgumentException e) {
             log.info("프로필 이미지 추출 실패");
         }
 


### PR DESCRIPTION
# 🚀 Pull Request

토큰 확인용 API 에러 해결

## #️⃣ 연관된 이슈

#121

## 📋 작업 내용

FileSerive.getFilePath() 메서드에서 추가된 예외(IllegalArgumentException)를 처리할 수 있도록 수정