### PR TITLE
update: 전략 등록시 저장된 전략id 반환

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
@@ -43,13 +43,12 @@ public class TraderStrategyController {
     )
     @PostMapping(value = "/strategy", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     // @PreAuthorize("hasRole('ROLE_TRADER'))
-    public ResponseEntity<APIResponse> insertStrategy(
+    public ResponseEntity<APIResponse<StrategyPostResponseDto>> insertStrategy(
             @RequestPart("requestDto") @Parameter(description = "전략 등록 요청 DTO") @Valid StrategyPostRequestDto requestDto,
             @RequestPart(value = "file", required = false) MultipartFile file
     ) {
-        traderStrategyService.insertStrategy(requestDto, file);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(APIResponse.success());
+                .body(APIResponse.success(traderStrategyService.insertStrategy(requestDto, file)));
     }
 
     // 전략 수정

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/dto/StrategyPostResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/dto/StrategyPostResponseDto.java
@@ -1,0 +1,17 @@
+package com.be3c.sysmetic.domain.strategy.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Setter
+@Getter
+@ToString
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class StrategyPostResponseDto {
+    @Schema(description = "등록된 전략 식별번호", example = "1")
+    @NotNull
+    private Long strategyId;
+}

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/exception/handler/StrategyExceptionHandler.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/exception/handler/StrategyExceptionHandler.java
@@ -4,6 +4,7 @@ import com.be3c.sysmetic.domain.strategy.exception.StrategyBadRequestException;
 import com.be3c.sysmetic.domain.strategy.exception.StrategyExceptionMessage;
 import com.be3c.sysmetic.global.common.response.APIResponse;
 import com.be3c.sysmetic.global.common.response.ErrorCode;
+import com.be3c.sysmetic.global.exception.ConflictException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -37,5 +38,11 @@ public class StrategyExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<APIResponse> badRequest(EntityNotFoundException exception) {
         return ResponseEntity.badRequest().body(APIResponse.fail(ErrorCode.BAD_REQUEST, StrategyExceptionMessage.DATA_NOT_FOUND.getMessage()));
+    }
+
+    // conflict
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<APIResponse> conflict(ConflictException exception) {
+        return ResponseEntity.badRequest().body(APIResponse.fail(ErrorCode.DUPLICATE_RESOURCE, exception.getMessage()));
     }
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/TraderStrategyService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/TraderStrategyService.java
@@ -1,10 +1,11 @@
 package com.be3c.sysmetic.domain.strategy.service;
 
 import com.be3c.sysmetic.domain.strategy.dto.StrategyPostRequestDto;
+import com.be3c.sysmetic.domain.strategy.dto.StrategyPostResponseDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface TraderStrategyService {
-    void insertStrategy(StrategyPostRequestDto requestDto, MultipartFile file);
+    StrategyPostResponseDto insertStrategy(StrategyPostRequestDto requestDto, MultipartFile file);
     void updateStrategy(Long strategyId, StrategyPostRequestDto requestDto, MultipartFile file);
     void deleteStrategy(Long strategyId);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/TraderStrategyServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/TraderStrategyServiceImpl.java
@@ -13,12 +13,14 @@ import com.be3c.sysmetic.domain.strategy.repository.MethodRepository;
 import com.be3c.sysmetic.domain.strategy.repository.StockRepository;
 import com.be3c.sysmetic.domain.strategy.repository.StrategyRepository;
 import com.be3c.sysmetic.domain.strategy.repository.StrategyStockReferenceRepository;
+import com.be3c.sysmetic.global.exception.ConflictException;
 import com.be3c.sysmetic.global.util.SecurityUtils;
 import com.be3c.sysmetic.global.util.file.dto.FileReferenceType;
 import com.be3c.sysmetic.global.util.file.dto.FileRequest;
 import com.be3c.sysmetic.global.util.file.service.FileServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,7 +45,7 @@ public class TraderStrategyServiceImpl implements TraderStrategyService {
     // 전략 등록
     @Override
     @Transactional
-    public void insertStrategy(StrategyPostRequestDto requestDto, MultipartFile file) {
+    public StrategyPostResponseDto insertStrategy(StrategyPostRequestDto requestDto, MultipartFile file) {
         checkDuplName(requestDto.getName());
 
         Strategy saveStrategy = Strategy.builder()
@@ -70,6 +72,8 @@ public class TraderStrategyServiceImpl implements TraderStrategyService {
         }
 
         insertStrategyStockReference(requestDto.getStockIdList(), saveStrategy);
+
+        return StrategyPostResponseDto.builder().strategyId(saveStrategy.getId()).build();
     }
 
     // 전략 수정
@@ -134,7 +138,7 @@ public class TraderStrategyServiceImpl implements TraderStrategyService {
     // 전략명 중복 여부 검증
     private void checkDuplName(String name) {
         if(strategyRepository.existsByName(name)) {
-            throw new StrategyBadRequestException(StrategyExceptionMessage.DUPLICATE_STRATEGY_NAME.getMessage());
+            throw new ConflictException(StrategyExceptionMessage.DUPLICATE_STRATEGY_NAME.getMessage());
         }
     }
 


### PR DESCRIPTION
# 🚀 Pull Request

전략 등록시 기존에 빈 값을 반환하던 api를 저장된 전략 id를 반환하도록 수정

## #️⃣ 연관된 이슈

#132 
## 📋 작업 내용

전략 등록시 기존 api에서는 빈 값을 반환했으나, 프론트엔드측 요청으로 저장된 전략 id를 반환하도록 수정했습니다.
