### PR TITLE
fix: API 요청시 파일 최대 크기 변경

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.config.import=classpath:database.properties, cloud.properties, jwt.properties
+
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=40MB


### PR DESCRIPTION
# 🚀 Pull Request

파일 최대 크기 변경 

## #️⃣ 연관된 이슈

#142 

## 📋 작업 내용

api 요청시 파일 최대 크기가 Spring에서 기본 1MB로 설정되어 있어 발생하는 이슈 해결
application.properties에 파일 개별 크기, 전체 요청 크기 각각 5MB, 40MB로 설정

