### PR TITLE
fix: 문의, 공지사항 상세 페이지 에러 발생 수정 #187

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
@@ -4,6 +4,7 @@ import com.be3c.sysmetic.domain.member.dto.*;
 import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.InquiryAnswer;
 import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
+import com.be3c.sysmetic.domain.member.repository.InquiryRepository;
 import com.be3c.sysmetic.domain.member.service.InquiryAnswerService;
 import com.be3c.sysmetic.domain.member.service.InquiryService;
 import com.be3c.sysmetic.domain.strategy.entity.Strategy;
@@ -34,6 +35,7 @@ public class InquiryController implements InquiryControllerDocs {
     private final InquiryAnswerService inquiryAnswerService;
 
     private final Integer pageSize = 10; // 한 페이지 크기
+    private final InquiryRepository inquiryRepository;
 
     /*
         관리자 문의 조회 / 검색 API
@@ -136,8 +138,8 @@ public class InquiryController implements InquiryControllerDocs {
 
         try {
             Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
-            Inquiry previousInquiry = inquiryService.findOneInquiry(inquiryId-1);
-            Inquiry nextInquiry = inquiryService.findOneInquiry(inquiryId+1);
+            Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(Inquiry.createInquiry(null, null, null, null));
+            Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(Inquiry.createInquiry(null, null, null, null));
 
             InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
 
@@ -408,8 +410,8 @@ public class InquiryController implements InquiryControllerDocs {
 
          try {
              Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
-             Inquiry previousInquiry = inquiryService.findOneInquiry(inquiryId-1);
-             Inquiry nextInquiry = inquiryService.findOneInquiry(inquiryId+1);
+             Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(Inquiry.createInquiry(null, null, null, null));
+             Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(Inquiry.createInquiry(null, null, null, null));
 
              InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
 
@@ -717,8 +719,8 @@ public class InquiryController implements InquiryControllerDocs {
 
         try {
             Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
-            Inquiry previousInquiry = inquiryService.findOneInquiry(inquiryId-1);
-            Inquiry nextInquiry = inquiryService.findOneInquiry(inquiryId+1);
+            Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(Inquiry.createInquiry(null, null, null, null));
+            Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(Inquiry.createInquiry(null, null, null, null));
 
             InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
@@ -140,29 +140,11 @@ public class InquiryController implements InquiryControllerDocs {
         }
 
         try {
-            Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow(EntityNotFoundException::new);
-            String previousInquiryTitle;
-            LocalDateTime previousInquiryWriteDate;
-            List<Inquiry> previousInquiryList = inquiryService.findPreviousInquiry(inquiryId);
-            if (previousInquiryList.isEmpty()) {
-                previousInquiryTitle = null;
-                previousInquiryWriteDate = null;
-            } else {
-                Inquiry previousInquiry = previousInquiryList.get(0);
-                previousInquiryTitle = previousInquiry.getInquiryTitle();
-                previousInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
-            }
-            String nextInquiryTitle;
-            LocalDateTime nextInquiryWriteDate;
-            List<Inquiry> nextInquiryList = inquiryService.findNextInquiry(inquiryId);
-            if (nextInquiryList.isEmpty()) {
-                nextInquiryTitle = null;
-                nextInquiryWriteDate = null;
-            } else {
-                Inquiry nextInquiry = nextInquiryList.get(0);
-                nextInquiryTitle = nextInquiry.getInquiryTitle();
-                nextInquiryWriteDate = nextInquiry.getInquiryRegistrationDate();
-            }
+            Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
+            String previousInquiryTitle = inquiryService.findPreviousInquiryTitle(inquiryId);
+            LocalDateTime previousInquiryWriteDate = inquiryService.findPreviousInquiryWriteDate(inquiryId);
+            String nextInquiryTitle = inquiryService.findNextInquiryTitle(inquiryId);
+            LocalDateTime nextInquiryWriteDate = inquiryService.findNextInquiryWriteDate(inquiryId);
 
             Long inquiryAnswerId;
             String answerTitle;
@@ -447,29 +429,11 @@ public class InquiryController implements InquiryControllerDocs {
          }
 
          try {
-             Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow(EntityNotFoundException::new);
-             String previousInquiryTitle;
-             LocalDateTime previousInquiryWriteDate;
-             List<Inquiry> previousInquiryList = inquiryService.findPreviousInquiry(inquiryId);
-             if (previousInquiryList.isEmpty()) {
-                 previousInquiryTitle = null;
-                 previousInquiryWriteDate = null;
-             } else {
-                 Inquiry previousInquiry = previousInquiryList.get(0);
-                 previousInquiryTitle = previousInquiry.getInquiryTitle();
-                 previousInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
-             }
-             String nextInquiryTitle;
-             LocalDateTime nextInquiryWriteDate;
-             List<Inquiry> nextInquiryList = inquiryService.findNextInquiry(inquiryId);
-             if (nextInquiryList.isEmpty()) {
-                 nextInquiryTitle = null;
-                 nextInquiryWriteDate = null;
-             } else {
-                 Inquiry nextInquiry = nextInquiryList.get(0);
-                 nextInquiryTitle = nextInquiry.getInquiryTitle();
-                 nextInquiryWriteDate = nextInquiry.getInquiryRegistrationDate();
-             }
+             Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
+             String previousInquiryTitle = inquiryService.findPreviousInquiryTitle(inquiryId);
+             LocalDateTime previousInquiryWriteDate = inquiryService.findPreviousInquiryWriteDate(inquiryId);
+             String nextInquiryTitle = inquiryService.findNextInquiryTitle(inquiryId);
+             LocalDateTime nextInquiryWriteDate = inquiryService.findNextInquiryWriteDate(inquiryId);
 
              Long inquiryAnswerId;
              String answerTitle;
@@ -561,7 +525,7 @@ public class InquiryController implements InquiryControllerDocs {
                         .body(APIResponse.fail(ErrorCode.BAD_REQUEST, "쿼리 파라미터 sort가 올바르지 않습니다."));
             }
 
-            Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow(EntityNotFoundException::new);
+            Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
 
             if(!Objects.equals(securityUtils.getUserIdInSecurityContext(), inquiry.getInquirer().getId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
@@ -603,8 +567,7 @@ public class InquiryController implements InquiryControllerDocs {
             @RequestBody @Valid InquiryModifyRequestDto inquiryModifyRequestDto) {
 
         try {
-
-            Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow(EntityNotFoundException::new);
+            Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
 
             if(!Objects.equals(securityUtils.getUserIdInSecurityContext(), inquiry.getInquirer().getId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
@@ -647,8 +610,7 @@ public class InquiryController implements InquiryControllerDocs {
             @PathVariable(name="inquiryId") Long inquiryId) {
 
         try {
-
-            Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow(EntityNotFoundException::new);
+            Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
 
             if(!Objects.equals(securityUtils.getUserIdInSecurityContext(), inquiry.getInquirer().getId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
@@ -793,29 +755,11 @@ public class InquiryController implements InquiryControllerDocs {
         }
 
         try {
-            Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow(EntityNotFoundException::new);
-            String previousInquiryTitle;
-            LocalDateTime previousInquiryWriteDate;
-            List<Inquiry> previousInquiryList = inquiryService.findPreviousInquiry(inquiryId);
-            if (previousInquiryList.isEmpty()) {
-                previousInquiryTitle = null;
-                previousInquiryWriteDate = null;
-            } else {
-                Inquiry previousInquiry = previousInquiryList.get(0);
-                previousInquiryTitle = previousInquiry.getInquiryTitle();
-                previousInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
-            }
-            String nextInquiryTitle;
-            LocalDateTime nextInquiryWriteDate;
-            List<Inquiry> nextInquiryList = inquiryService.findNextInquiry(inquiryId);
-            if (nextInquiryList.isEmpty()) {
-                nextInquiryTitle = null;
-                nextInquiryWriteDate = null;
-            } else {
-                Inquiry nextInquiry = nextInquiryList.get(0);
-                nextInquiryTitle = nextInquiry.getInquiryTitle();
-                nextInquiryWriteDate = nextInquiry.getInquiryRegistrationDate();
-            }
+            Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
+            String previousInquiryTitle = inquiryService.findPreviousInquiryTitle(inquiryId);
+            LocalDateTime previousInquiryWriteDate = inquiryService.findPreviousInquiryWriteDate(inquiryId);
+            String nextInquiryTitle = inquiryService.findNextInquiryTitle(inquiryId);
+            LocalDateTime nextInquiryWriteDate = inquiryService.findNextInquiryWriteDate(inquiryId);
 
             Long inquiryAnswerId;
             String answerTitle;

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
@@ -4,6 +4,7 @@ import com.be3c.sysmetic.domain.member.dto.*;
 import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.InquiryAnswer;
 import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
+import com.be3c.sysmetic.domain.member.entity.Notice;
 import com.be3c.sysmetic.domain.member.repository.InquiryRepository;
 import com.be3c.sysmetic.domain.member.service.InquiryAnswerService;
 import com.be3c.sysmetic.domain.member.service.InquiryService;
@@ -20,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -138,10 +140,43 @@ public class InquiryController implements InquiryControllerDocs {
 
         try {
             Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
-            Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(Inquiry.createInquiry(null, null, null, null));
-            Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(Inquiry.createInquiry(null, null, null, null));
+            String previousInquiryTitle;
+            LocalDateTime previousInquiryWriteDate;
+            Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(null);
+            if (previousInquiry == null) {
+                previousInquiryTitle = null;
+                previousInquiryWriteDate = null;
+            } else {
+                previousInquiryTitle = previousInquiry.getInquiryTitle();
+                previousInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
+            }
+            String nextInquiryTitle;
+            LocalDateTime nextInquiryWriteDate;
+            Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(null);
+            if (nextInquiry == null) {
+                nextInquiryTitle = null;
+                nextInquiryWriteDate = null;
+            } else {
+                nextInquiryTitle = nextInquiry.getInquiryTitle();
+                nextInquiryWriteDate = nextInquiry.getInquiryRegistrationDate();
+            }
 
-            InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
+            Long inquiryAnswerId;
+            String answerTitle;
+            LocalDateTime answerRegistrationDate;
+            String answerContent;
+            if (inquiry.getInquiryStatus() == InquiryStatus.unclosed) {
+                inquiryAnswerId = null;
+                answerTitle = null;
+                answerRegistrationDate = null;
+                answerContent = null;
+            } else {
+                InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
+                inquiryAnswerId = inquiryAnswer.getId();
+                answerTitle = inquiryAnswer.getAnswerTitle();
+                answerRegistrationDate = inquiryAnswer.getAnswerRegistrationDate();
+                answerContent = inquiryAnswer.getAnswerContent();
+            }
 
             InquiryAnswerShowResponseDto inquiryAnswerShowResponseDto = InquiryAnswerShowResponseDto.builder()
                     .page(page)
@@ -150,7 +185,7 @@ public class InquiryController implements InquiryControllerDocs {
                     .searchText(searchText)
 
                     .inquiryId(inquiryId)
-                    .inquiryAnswerId(inquiryAnswer.getId())
+                    .inquiryAnswerId(inquiryAnswerId)
 
                     .inquiryTitle(inquiry.getInquiryTitle())
                     .inquiryRegistrationDate(inquiry.getInquiryRegistrationDate())
@@ -164,14 +199,14 @@ public class InquiryController implements InquiryControllerDocs {
 
                     .inquiryContent(inquiry.getInquiryContent())
 
-                    .answerTitle(inquiryAnswer.getAnswerTitle())
-                    .answerRegistrationDate(inquiryAnswer.getAnswerRegistrationDate())
-                    .answerContent(inquiryAnswer.getAnswerContent())
+                    .answerTitle(answerTitle)
+                    .answerRegistrationDate(answerRegistrationDate)
+                    .answerContent(answerContent)
 
-                    .previousTitle(previousInquiry.getInquiryTitle())
-                    .previousWriteDate(previousInquiry.getInquiryRegistrationDate())
-                    .nextTitle(nextInquiry.getInquiryTitle())
-                    .nextWriteDate(nextInquiry.getInquiryRegistrationDate())
+                    .previousTitle(previousInquiryTitle)
+                    .previousWriteDate(previousInquiryWriteDate)
+                    .nextTitle(nextInquiryTitle)
+                    .nextWriteDate(nextInquiryWriteDate)
                     .build();
 
             return ResponseEntity.status(HttpStatus.OK)
@@ -410,10 +445,43 @@ public class InquiryController implements InquiryControllerDocs {
 
          try {
              Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
-             Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(Inquiry.createInquiry(null, null, null, null));
-             Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(Inquiry.createInquiry(null, null, null, null));
+             String previousInquiryTitle;
+             LocalDateTime previousInquiryWriteDate;
+             Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(null);
+             if (previousInquiry == null) {
+                 previousInquiryTitle = null;
+                 previousInquiryWriteDate = null;
+             } else {
+                 previousInquiryTitle = previousInquiry.getInquiryTitle();
+                 previousInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
+             }
+             String nextInquiryTitle;
+             LocalDateTime nextInquiryWriteDate;
+             Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(null);
+             if (nextInquiry == null) {
+                 nextInquiryTitle = null;
+                 nextInquiryWriteDate = null;
+             } else {
+                 nextInquiryTitle = nextInquiry.getInquiryTitle();
+                 nextInquiryWriteDate = nextInquiry.getInquiryRegistrationDate();
+             }
 
-             InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
+             Long inquiryAnswerId;
+             String answerTitle;
+             LocalDateTime answerRegistrationDate;
+             String answerContent;
+             if (inquiry.getInquiryStatus() == InquiryStatus.unclosed) {
+                 inquiryAnswerId = null;
+                 answerTitle = null;
+                 answerRegistrationDate = null;
+                 answerContent = null;
+             } else {
+                 InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
+                 inquiryAnswerId = inquiryAnswer.getId();
+                 answerTitle = inquiryAnswer.getAnswerTitle();
+                 answerRegistrationDate = inquiryAnswer.getAnswerRegistrationDate();
+                 answerContent = inquiryAnswer.getAnswerContent();
+             }
 
              InquiryAnswerShowResponseDto inquiryAnswerShowResponseDto = InquiryAnswerShowResponseDto.builder()
                      .page(page)
@@ -421,7 +489,7 @@ public class InquiryController implements InquiryControllerDocs {
                      .closed(closed)
 
                      .inquiryId(inquiryId)
-                     .inquiryAnswerId(inquiryAnswer.getId())
+                     .inquiryAnswerId(inquiryAnswerId)
 
                      .inquiryTitle(inquiry.getInquiryTitle())
                      .inquiryRegistrationDate(inquiry.getInquiryRegistrationDate())
@@ -435,14 +503,14 @@ public class InquiryController implements InquiryControllerDocs {
 
                      .inquiryContent(inquiry.getInquiryContent())
 
-                     .answerTitle(inquiryAnswer.getAnswerTitle())
-                     .answerRegistrationDate(inquiryAnswer.getAnswerRegistrationDate())
-                     .answerContent(inquiryAnswer.getAnswerContent())
+                     .answerTitle(answerTitle)
+                     .answerRegistrationDate(answerRegistrationDate)
+                     .answerContent(answerContent)
 
-                     .previousTitle(previousInquiry.getInquiryTitle())
-                     .previousWriteDate(previousInquiry.getInquiryRegistrationDate())
-                     .nextTitle(nextInquiry.getInquiryTitle())
-                     .nextWriteDate(nextInquiry.getInquiryRegistrationDate())
+                     .previousTitle(previousInquiryTitle)
+                     .previousWriteDate(previousInquiryWriteDate)
+                     .nextTitle(nextInquiryTitle)
+                     .nextWriteDate(nextInquiryWriteDate)
                      .build();
 
              return ResponseEntity.status(HttpStatus.OK)
@@ -719,10 +787,43 @@ public class InquiryController implements InquiryControllerDocs {
 
         try {
             Inquiry inquiry = inquiryService.findOneInquiry(inquiryId);
-            Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(Inquiry.createInquiry(null, null, null, null));
-            Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(Inquiry.createInquiry(null, null, null, null));
+            String previousInquiryTitle;
+            LocalDateTime previousInquiryWriteDate;
+            Inquiry previousInquiry = inquiryRepository.findById(inquiryId-1).orElse(null);
+            if (previousInquiry == null) {
+                previousInquiryTitle = null;
+                previousInquiryWriteDate = null;
+            } else {
+                previousInquiryTitle = previousInquiry.getInquiryTitle();
+                previousInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
+            }
+            String nextInquiryTitle;
+            LocalDateTime nextInquiryWriteDate;
+            Inquiry nextInquiry = inquiryRepository.findById(inquiryId+1).orElse(null);
+            if (nextInquiry == null) {
+                nextInquiryTitle = null;
+                nextInquiryWriteDate = null;
+            } else {
+                nextInquiryTitle = nextInquiry.getInquiryTitle();
+                nextInquiryWriteDate = nextInquiry.getInquiryRegistrationDate();
+            }
 
-            InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
+            Long inquiryAnswerId;
+            String answerTitle;
+            LocalDateTime answerRegistrationDate;
+            String answerContent;
+            if (inquiry.getInquiryStatus() == InquiryStatus.unclosed) {
+                inquiryAnswerId = null;
+                answerTitle = null;
+                answerRegistrationDate = null;
+                answerContent = null;
+            } else {
+                InquiryAnswer inquiryAnswer = inquiryAnswerService.findThatInquiryAnswer(inquiryId);
+                inquiryAnswerId = inquiryAnswer.getId();
+                answerTitle = inquiryAnswer.getAnswerTitle();
+                answerRegistrationDate = inquiryAnswer.getAnswerRegistrationDate();
+                answerContent = inquiryAnswer.getAnswerContent();
+            }
 
             InquiryAnswerShowResponseDto inquiryAnswerShowResponseDto = InquiryAnswerShowResponseDto.builder()
                     .page(page)
@@ -730,7 +831,7 @@ public class InquiryController implements InquiryControllerDocs {
                     .closed(closed)
 
                     .inquiryId(inquiryId)
-                    .inquiryAnswerId(inquiryAnswer.getId())
+                    .inquiryAnswerId(inquiryAnswerId)
 
                     .inquiryTitle(inquiry.getInquiryTitle())
                     .inquiryRegistrationDate(inquiry.getInquiryRegistrationDate())
@@ -744,14 +845,14 @@ public class InquiryController implements InquiryControllerDocs {
 
                     .inquiryContent(inquiry.getInquiryContent())
 
-                    .answerTitle(inquiryAnswer.getAnswerTitle())
-                    .answerRegistrationDate(inquiryAnswer.getAnswerRegistrationDate())
-                    .answerContent(inquiryAnswer.getAnswerContent())
+                    .answerTitle(answerTitle)
+                    .answerRegistrationDate(answerRegistrationDate)
+                    .answerContent(answerContent)
 
-                    .previousTitle(previousInquiry.getInquiryTitle())
-                    .previousWriteDate(previousInquiry.getInquiryRegistrationDate())
-                    .nextTitle(nextInquiry.getInquiryTitle())
-                    .nextWriteDate(nextInquiry.getInquiryRegistrationDate())
+                    .previousTitle(previousInquiryTitle)
+                    .previousWriteDate(previousInquiryWriteDate)
+                    .nextTitle(nextInquiryTitle)
+                    .nextWriteDate(nextInquiryWriteDate)
                     .build();
 
             return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
@@ -22,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -204,8 +205,26 @@ public class NoticeContoller implements NoticeControllerDocs {
             noticeService.upHits(noticeId);
 
             Notice notice = noticeService.findNoticeById(noticeId);
-            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(Notice.createNotice(null, null, null, null, null));
-            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(Notice.createNotice(null, null, null, null, null));
+            String previousNoticeTitle;
+            LocalDateTime previousNoticeWriteDate;
+            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(null);
+            if (previousNotice == null) {
+                previousNoticeTitle = null;
+                previousNoticeWriteDate = null;
+            } else {
+                previousNoticeTitle = previousNotice.getNoticeTitle();
+                previousNoticeWriteDate = previousNotice.getWriteDate();
+            }
+            String nextNoticeTitle;
+            LocalDateTime nextNoticeWriteDate;
+            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(null);
+            if (nextNotice == null) {
+                nextNoticeTitle = null;
+                nextNoticeWriteDate = null;
+            } else {
+                nextNoticeTitle = nextNotice.getNoticeTitle();
+                nextNoticeWriteDate = nextNotice.getWriteDate();
+            }
 
             List<FileWithInfoResponse> fileList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_FILE, notice.getId()));
             List<FileWithInfoResponse> imageList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_IMAGE, notice.getId()));
@@ -245,10 +264,10 @@ public class NoticeContoller implements NoticeControllerDocs {
                     .isOpen(notice.getIsOpen())
                     .fileDtoList(fileDtoList)
                     .imageDtoList(imageDtoList)
-                    .previousTitle(previousNotice.getNoticeTitle())
-                    .previousWriteDate(previousNotice.getWriteDate())
-                    .nextTitle(nextNotice.getNoticeTitle())
-                    .nextWriteDate(nextNotice.getWriteDate())
+                    .previousTitle(previousNoticeTitle)
+                    .previousWriteDate(previousNoticeWriteDate)
+                    .nextTitle(nextNoticeTitle)
+                    .nextWriteDate(nextNoticeWriteDate)
                     .build();
 
             return ResponseEntity.status(HttpStatus.OK)
@@ -524,8 +543,26 @@ public class NoticeContoller implements NoticeControllerDocs {
 
         try {
             Notice notice = noticeService.findNoticeById(noticeId);
-            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(Notice.createNotice(null, null, null, null, null));
-            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(Notice.createNotice(null, null, null, null, null));
+            String previousNoticeTitle;
+            LocalDateTime previousNoticeWriteDate;
+            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(null);
+            if (previousNotice == null) {
+                previousNoticeTitle = null;
+                previousNoticeWriteDate = null;
+            } else {
+                previousNoticeTitle = previousNotice.getNoticeTitle();
+                previousNoticeWriteDate = previousNotice.getWriteDate();
+            }
+            String nextNoticeTitle;
+            LocalDateTime nextNoticeWriteDate;
+            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(null);
+            if (nextNotice == null) {
+                nextNoticeTitle = null;
+                nextNoticeWriteDate = null;
+            } else {
+                nextNoticeTitle = nextNotice.getNoticeTitle();
+                nextNoticeWriteDate = nextNotice.getWriteDate();
+            }
 
             List<FileWithInfoResponse> fileList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_FILE, notice.getId()));
             List<FileWithInfoResponse> imageList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_IMAGE, notice.getId()));
@@ -564,10 +601,10 @@ public class NoticeContoller implements NoticeControllerDocs {
                     .isOpen(notice.getIsOpen())
                     .fileDtoList(fileDtoList)
                     .imageDtoList(imageDtoList)
-                    .previousTitle(previousNotice.getNoticeTitle())
-                    .previousWriteDate(previousNotice.getWriteDate())
-                    .nextTitle(nextNotice.getNoticeTitle())
-                    .nextWriteDate(nextNotice.getWriteDate())
+                    .previousTitle(previousNoticeTitle)
+                    .previousWriteDate(previousNoticeWriteDate)
+                    .nextTitle(nextNoticeTitle)
+                    .nextWriteDate(nextNoticeWriteDate)
                     .build();
 
             return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
@@ -74,7 +74,7 @@ public class NoticeContoller implements NoticeControllerDocs {
                     userId,
                     noticeSaveRequestDto.getNoticeTitle(),
                     noticeSaveRequestDto.getNoticeContent(),
-//                    noticeSaveRequestDto.getIsAttachment(),
+                    noticeSaveRequestDto.getIsAttachment(),
                     noticeSaveRequestDto.getIsOpen(),
                     fileList,
                     imageList)) {
@@ -383,14 +383,13 @@ public class NoticeContoller implements NoticeControllerDocs {
         Long userId = securityUtils.getUserIdInSecurityContext();
 
         try {
-            Notice notice = noticeService.findNoticeById(noticeId);
-
 
             if (noticeService.modifyNotice(
                     noticeId,
                     noticeModifyRequestDto.getNoticeTitle(),
                     noticeModifyRequestDto.getNoticeContent(),
                     userId,
+                    noticeModifyRequestDto.getIsAttachment(),
                     noticeModifyRequestDto.getIsOpen(),
                     noticeModifyRequestDto.getExistFileDtoList(),
                     noticeModifyRequestDto.getExistImageDtoList(),
@@ -594,11 +593,6 @@ public class NoticeContoller implements NoticeControllerDocs {
                     .noticeTitle(notice.getNoticeTitle())
                     .noticeContent(notice.getNoticeContent())
                     .writeDate(notice.getWriteDate())
-                    .correctDate(notice.getCorrectDate())
-                    .writerNickname(notice.getWriterNickname())
-                    .hits(notice.getHits())
-                    .isAttachment(notice.getIsAttachment())
-                    .isOpen(notice.getIsOpen())
                     .fileDtoList(fileDtoList)
                     .imageDtoList(imageDtoList)
                     .previousTitle(previousNoticeTitle)

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
@@ -2,6 +2,7 @@ package com.be3c.sysmetic.domain.member.controller;
 
 import com.be3c.sysmetic.domain.member.dto.*;
 import com.be3c.sysmetic.domain.member.entity.Notice;
+import com.be3c.sysmetic.domain.member.repository.NoticeRepository;
 import com.be3c.sysmetic.domain.member.service.NoticeService;
 import com.be3c.sysmetic.global.common.response.APIResponse;
 import com.be3c.sysmetic.global.common.response.ErrorCode;
@@ -21,8 +22,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +38,7 @@ public class NoticeContoller implements NoticeControllerDocs {
     private final FileService fileService;
 
     private final Integer pageSize = 10; // 한 페이지 크기
+    private final NoticeRepository noticeRepository;
 
     /*
         관리자 공지사항 등록 API
@@ -204,8 +204,8 @@ public class NoticeContoller implements NoticeControllerDocs {
             noticeService.upHits(noticeId);
 
             Notice notice = noticeService.findNoticeById(noticeId);
-            Notice previousNotice = noticeService.findNoticeById(noticeId-1);
-            Notice nextNotice = noticeService.findNoticeById(noticeId+1);
+            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(Notice.createNotice(null, null, null, null, null));
+            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(Notice.createNotice(null, null, null, null, null));
 
             List<FileWithInfoResponse> fileList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_FILE, notice.getId()));
             List<FileWithInfoResponse> imageList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_IMAGE, notice.getId()));
@@ -524,8 +524,8 @@ public class NoticeContoller implements NoticeControllerDocs {
 
         try {
             Notice notice = noticeService.findNoticeById(noticeId);
-            Notice previousNotice = noticeService.findNoticeById(noticeId-1);
-            Notice nextNotice = noticeService.findNoticeById(noticeId+1);
+            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(Notice.createNotice(null, null, null, null, null));
+            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(Notice.createNotice(null, null, null, null, null));
 
             List<FileWithInfoResponse> fileList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_FILE, notice.getId()));
             List<FileWithInfoResponse> imageList = fileService.getFileWithInfos(new FileRequest(FileReferenceType.NOTICE_BOARD_IMAGE, notice.getId()));

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
@@ -210,28 +210,10 @@ public class NoticeContoller implements NoticeControllerDocs {
         try {
 
             Notice notice = noticeService.findNoticeById(noticeId);
-            String previousNoticeTitle;
-            LocalDateTime previousNoticeWriteDate;
-            List<Notice> previousNoticeList = noticeService.findPreviousNotice(noticeId);
-            if (previousNoticeList.isEmpty()) {
-                previousNoticeTitle = null;
-                previousNoticeWriteDate = null;
-            } else {
-                Notice previousNotice = previousNoticeList.get(0);
-                previousNoticeTitle = previousNotice.getNoticeTitle();
-                previousNoticeWriteDate = previousNotice.getWriteDate();
-            }
-            String nextNoticeTitle;
-            LocalDateTime nextNoticeWriteDate;
-            List<Notice> nextNoticeList = noticeService.findNextNotice(noticeId);
-            if (nextNoticeList.isEmpty()) {
-                nextNoticeTitle = null;
-                nextNoticeWriteDate = null;
-            } else {
-                Notice nextNotice = nextNoticeList.get(0);
-                nextNoticeTitle = nextNotice.getNoticeTitle();
-                nextNoticeWriteDate = nextNotice.getWriteDate();
-            }
+            String previousNoticeTitle = noticeService.findPreviousNoticeTitle(noticeId);
+            LocalDateTime previousNoticeWriteDate = noticeService.findPreviousNoticeWriteDate(noticeId);
+            String nextNoticeTitle = noticeService.findNextNoticeTitle(noticeId);
+            LocalDateTime nextNoticeWriteDate = noticeService.findNextNoticeWriteDate(noticeId);
 
             List<NoticeDetailFileShowResponseDto> fileDtoList = null;
             if (notice.getFileExists()) {
@@ -568,28 +550,10 @@ public class NoticeContoller implements NoticeControllerDocs {
             noticeService.upHits(noticeId);
 
             Notice notice = noticeService.findNoticeById(noticeId);
-            String previousNoticeTitle;
-            LocalDateTime previousNoticeWriteDate;
-            List<Notice> previousNoticeList = noticeService.findPreviousNotice(noticeId);
-            if (previousNoticeList.isEmpty()) {
-                previousNoticeTitle = null;
-                previousNoticeWriteDate = null;
-            } else {
-                Notice previousNotice = previousNoticeList.get(0);
-                previousNoticeTitle = previousNotice.getNoticeTitle();
-                previousNoticeWriteDate = previousNotice.getWriteDate();
-            }
-            String nextNoticeTitle;
-            LocalDateTime nextNoticeWriteDate;
-            List<Notice> nextNoticeList = noticeService.findNextNotice(noticeId);
-            if (nextNoticeList.isEmpty()) {
-                nextNoticeTitle = null;
-                nextNoticeWriteDate = null;
-            } else {
-                Notice nextNotice = nextNoticeList.get(0);
-                nextNoticeTitle = nextNotice.getNoticeTitle();
-                nextNoticeWriteDate = nextNotice.getWriteDate();
-            }
+            String previousNoticeTitle = noticeService.findPreviousNoticeTitle(noticeId);
+            LocalDateTime previousNoticeWriteDate = noticeService.findPreviousNoticeWriteDate(noticeId);
+            String nextNoticeTitle = noticeService.findNextNoticeTitle(noticeId);
+            LocalDateTime nextNoticeWriteDate = noticeService.findNextNoticeWriteDate(noticeId);
 
             List<NoticeDetailFileShowResponseDto> fileDtoList = null;
             if (notice.getFileExists()) {

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
@@ -1,6 +1,7 @@
 package com.be3c.sysmetic.domain.member.controller;
 
 import com.be3c.sysmetic.domain.member.dto.*;
+import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.Notice;
 import com.be3c.sysmetic.domain.member.repository.NoticeRepository;
 import com.be3c.sysmetic.domain.member.service.NoticeService;
@@ -211,21 +212,23 @@ public class NoticeContoller implements NoticeControllerDocs {
             Notice notice = noticeService.findNoticeById(noticeId);
             String previousNoticeTitle;
             LocalDateTime previousNoticeWriteDate;
-            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(null);
-            if (previousNotice == null) {
+            List<Notice> previousNoticeList = noticeService.findPreviousNotice(noticeId);
+            if (previousNoticeList.isEmpty()) {
                 previousNoticeTitle = null;
                 previousNoticeWriteDate = null;
             } else {
+                Notice previousNotice = previousNoticeList.get(0);
                 previousNoticeTitle = previousNotice.getNoticeTitle();
                 previousNoticeWriteDate = previousNotice.getWriteDate();
             }
             String nextNoticeTitle;
             LocalDateTime nextNoticeWriteDate;
-            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(null);
-            if (nextNotice == null) {
+            List<Notice> nextNoticeList = noticeService.findNextNotice(noticeId);
+            if (nextNoticeList.isEmpty()) {
                 nextNoticeTitle = null;
                 nextNoticeWriteDate = null;
             } else {
+                Notice nextNotice = nextNoticeList.get(0);
                 nextNoticeTitle = nextNotice.getNoticeTitle();
                 nextNoticeWriteDate = nextNotice.getWriteDate();
             }
@@ -567,21 +570,23 @@ public class NoticeContoller implements NoticeControllerDocs {
             Notice notice = noticeService.findNoticeById(noticeId);
             String previousNoticeTitle;
             LocalDateTime previousNoticeWriteDate;
-            Notice previousNotice = noticeRepository.findById(noticeId-1).orElse(null);
-            if (previousNotice == null) {
+            List<Notice> previousNoticeList = noticeService.findPreviousNotice(noticeId);
+            if (previousNoticeList.isEmpty()) {
                 previousNoticeTitle = null;
                 previousNoticeWriteDate = null;
             } else {
+                Notice previousNotice = previousNoticeList.get(0);
                 previousNoticeTitle = previousNotice.getNoticeTitle();
                 previousNoticeWriteDate = previousNotice.getWriteDate();
             }
             String nextNoticeTitle;
             LocalDateTime nextNoticeWriteDate;
-            Notice nextNotice = noticeRepository.findById(noticeId+1).orElse(null);
-            if (nextNotice == null) {
+            List<Notice> nextNoticeList = noticeService.findNextNotice(noticeId);
+            if (nextNoticeList.isEmpty()) {
                 nextNoticeTitle = null;
                 nextNoticeWriteDate = null;
             } else {
+                Notice nextNotice = nextNoticeList.get(0);
                 nextNoticeTitle = nextNotice.getNoticeTitle();
                 nextNoticeWriteDate = nextNotice.getWriteDate();
             }

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeControllerDocs.java
@@ -195,8 +195,7 @@ public interface NoticeControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "데이터의 형식이 올바르지 않음 (BAD_REQUEST)"
-//                            "\n+ +) 공지사항 수정 화면에 들어온 시간이 해당 공지사항 최종수정일시보다 작음"
+                    description = "데이터의 형식이 올바르지 않음 (BAD_REQUEST)\n+ +) 공지사항 수정 화면에 들어온 시간이 해당 공지사항 최종수정일시보다 작음"
             )
     })
     ResponseEntity<APIResponse<Long>> modifyAdminNotice(

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeAdminListOneShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeAdminListOneShowResponseDto.java
@@ -29,8 +29,8 @@ public class NoticeAdminListOneShowResponseDto {
     @Schema(description = "조회수", example = "100")
     private Long hits;
 
-    @Schema(description = "첨부 파일 여부", example = "true")
-    private Boolean isAttachment;
+    @Schema(description = "첨부 파일 존재 여부", example = "true")
+    private Boolean fileExist;
 
     @Schema(description = "공개 여부", example = "false")
     private Boolean isOpen;

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailAdminShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailAdminShowResponseDto.java
@@ -45,8 +45,11 @@ public class NoticeDetailAdminShowResponseDto {
     @Schema(description = "조회수", example = "100")
     private Long hits;
 
-    @Schema(description = "첨부 파일 여부", example = "true")
-    private Boolean isAttachment;
+    @Schema(description = "첨부 파일 존재 여부", example = "true")
+    private Boolean fileExist;
+
+    @Schema(description = "이미지 파일 존재 여부", example = "true")
+    private Boolean imageExist;
 
     @Schema(description = "공개 여부", example = "true")
     private Boolean isOpen;

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailShowResponseDto.java
@@ -33,21 +33,6 @@ public class NoticeDetailShowResponseDto {
     @Schema(description = "작성일시", example = "2023-11-21T10:15:30")
     private LocalDateTime writeDate;
 
-    @Schema(description = "수정일시", example = "2023-11-22T14:00:00")
-    private LocalDateTime correctDate;
-
-    @Schema(description = "작성자 닉네임", example = "홍길동")
-    private String writerNickname;
-
-    @Schema(description = "조회수", example = "100")
-    private Long hits;
-
-    @Schema(description = "첨부 파일 여부", example = "true")
-    private Boolean isAttachment;
-
-    @Schema(description = "공개 여부", example = "true")
-    private Boolean isOpen;
-
     @Schema(description = "이 공지사항의 파일 정보를 담은 리스트", example = "[]")
     private List<NoticeDetailFileShowResponseDto> fileDtoList;
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeListOneShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeListOneShowResponseDto.java
@@ -23,6 +23,6 @@ public class NoticeListOneShowResponseDto {
     @Schema(description = "작성일시", example = "2023-11-21T10:15:30")
     private LocalDateTime writeDate;
 
-    @Schema(description = "첨부 파일 여부", example = "true")
-    private Boolean isAttachment;
+    @Schema(description = "첨부 파일 존재 여부", example = "true")
+    private Boolean fileExists;
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeModifyRequestDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeModifyRequestDto.java
@@ -29,9 +29,13 @@ public class NoticeModifyRequestDto {
     @NotNull
     private String noticeContent;
 
-    @Schema(description = "첨부 파일 여부", example = "true")
+    @Schema(description = "첨부 파일 존재 여부", example = "true")
     @NotNull
-    private Boolean isAttachment;
+    private Boolean fileExists;
+
+    @Schema(description = "이미지 파일 존재 여부", example = "true")
+    @NotNull
+    private Boolean imageExists;
 
     @Schema(description = "공개 여부", example = "true")
     @NotNull

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeSaveRequestDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeSaveRequestDto.java
@@ -20,9 +20,13 @@ public class NoticeSaveRequestDto {
     @NotNull
     private String noticeContent;
 
-    @Schema(description = "첨부 파일 여부", example = "true")
+    @Schema(description = "첨부 파일 존재 여부", example = "true")
     @NotNull
-    private Boolean isAttachment;
+    private Boolean fileExists;
+
+    @Schema(description = "이미지 파일 존재 여부", example = "true")
+    @NotNull
+    private Boolean imageExists;
 
     @Schema(description = "공개 여부", example = "true")
     @NotNull

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeSaveRequestDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeSaveRequestDto.java
@@ -20,9 +20,9 @@ public class NoticeSaveRequestDto {
     @NotNull
     private String noticeContent;
 
-//    @Schema(description = "첨부 파일 여부", example = "true")
-//    @NotNull
-//    private Boolean isAttachment;
+    @Schema(description = "첨부 파일 여부", example = "true")
+    @NotNull
+    private Boolean isAttachment;
 
     @Schema(description = "공개 여부", example = "true")
     @NotNull

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeShowModifyPageResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeShowModifyPageResponseDto.java
@@ -32,8 +32,11 @@ public class NoticeShowModifyPageResponseDto {
     @Schema(description = "공지사항 내용", example = "공지사항 내용 예시입니다.")
     private String noticeContent;
 
-    @Schema(description = "첨부 파일 여부", example = "true")
-    private Boolean isAttachment;
+    @Schema(description = "첨부 파일 존재 여부", example = "true")
+    private Boolean fileExist;
+
+    @Schema(description = "이미지 파일 존재 여부", example = "true")
+    private Boolean imageExist;
 
     @Schema(description = "공개 여부", example = "true")
     private Boolean isOpen;

--- a/src/main/java/com/be3c/sysmetic/domain/member/entity/Notice.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/entity/Notice.java
@@ -46,8 +46,11 @@ public class Notice extends BaseEntity {
     @Column(name = "hits", nullable = false)
     private Long hits;
 
-    @Column(name = "is_attachment", nullable = false)
-    private Boolean isAttachment;
+    @Column(name = "file_exists", nullable = false)
+    private Boolean fileExists;
+
+    @Column(name = "image_exists", nullable = false)
+    private Boolean ImageExists;
 
     @Column(name = "is_open", nullable = false)
     private Boolean isOpen;
@@ -55,7 +58,8 @@ public class Notice extends BaseEntity {
     public static Notice createNotice(String noticeTitle,
                                       String noticeContent,
                                       Member writer,
-                                      Boolean isAttachment,
+                                      Boolean fileExists,
+                                      Boolean imageExists,
                                       Boolean isOpen) {
 
         return Notice.builder()
@@ -67,7 +71,8 @@ public class Notice extends BaseEntity {
                 .correctorId(writer.getId())
                 .correctDate(LocalDateTime.now())
                 .hits(0L)
-                .isAttachment(isAttachment)
+                .fileExists(fileExists)
+                .ImageExists(imageExists)
                 .isOpen(isOpen)
                 .build();
     }

--- a/src/main/java/com/be3c/sysmetic/domain/member/entity/Notice.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/entity/Notice.java
@@ -50,7 +50,7 @@ public class Notice extends BaseEntity {
     private Boolean fileExists;
 
     @Column(name = "image_exists", nullable = false)
-    private Boolean ImageExists;
+    private Boolean imageExists;
 
     @Column(name = "is_open", nullable = false)
     private Boolean isOpen;
@@ -72,7 +72,7 @@ public class Notice extends BaseEntity {
                 .correctDate(LocalDateTime.now())
                 .hits(0L)
                 .fileExists(fileExists)
-                .ImageExists(imageExists)
+                .imageExists(imageExists)
                 .isOpen(isOpen)
                 .build();
     }

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long>, InquiryRepositoryCustom {
 
@@ -36,6 +37,14 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long>, Inquiry
     @Modifying(clearAutomatically = true)
     @Query("delete Inquiry i where i.id in :idList")
     int bulkDelete(@Param("idList") List<Long> idList);
+
+    // 이전 문의 조회
+    @Query("select i from Inquiry i where i.id < :inquiryId order by i.id desc")
+    List<Inquiry> findPreviousInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
+
+    // 다음 문의 조회
+    @Query("select i from Inquiry i where i.id > :inquiryId order by i.id asc")
+    List<Inquiry> findNextInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
 
     @Modifying
     @Query("DELETE FROM Inquiry i WHERE i.strategy.id = :strategyId")

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/NoticeRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/NoticeRepository.java
@@ -1,6 +1,8 @@
 package com.be3c.sysmetic.domain.member.repository;
 
+import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.Notice;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +22,12 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> , NoticeRe
 
     // 제목으로 찾기
     List<Notice> findByNoticeTitle(String noticeTitle);
+
+    // 이전 문의 조회
+    @Query("select n from Notice n where n.id < :noticeId order by n.id desc")
+    List<Notice> findPreviousNotice(@Param("noticeId") Long noticeId, Pageable pageable);
+
+    // 다음 문의 조회
+    @Query("select n from Notice n where n.id > :noticeId order by n.id asc")
+    List<Notice> findNextNotice(@Param("noticeId") Long noticeId, Pageable pageable);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
@@ -6,6 +6,7 @@ import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
 import com.be3c.sysmetic.domain.strategy.entity.Strategy;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -52,6 +53,11 @@ public interface InquiryService {
     // 관리자 목록 삭제
     Integer deleteAdminInquiryList(List<Long> inquiryIdList);
 
+    // 이전 문의 조회
+    List<Inquiry> findPreviousInquiry(Long inquiryId);
+
+    // 다음 문의 조회
+    List<Inquiry> findNextInquiry(Long inquiryId);
 
     // 관리자 검색 조회
     // 전체, 답변 대기, 답변 완료

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
@@ -8,6 +8,8 @@ import com.be3c.sysmetic.domain.strategy.entity.Strategy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface InquiryService {
@@ -53,11 +55,17 @@ public interface InquiryService {
     // 관리자 목록 삭제
     Integer deleteAdminInquiryList(List<Long> inquiryIdList);
 
-    // 이전 문의 조회
-    List<Inquiry> findPreviousInquiry(Long inquiryId);
+    // 이전 문의 제목 조회
+    String findPreviousInquiryTitle(Long inquiryId);
 
-    // 다음 문의 조회
-    List<Inquiry> findNextInquiry(Long inquiryId);
+    // 이전 문의 작성일 조회
+    LocalDateTime findPreviousInquiryWriteDate(Long inquiryId);
+
+    // 다음 문의 제목 조회
+    String findNextInquiryTitle(Long inquiryId);
+
+    // 다음 문의 제목 조회
+    LocalDateTime findNextInquiryWriteDate(Long inquiryId);
 
     // 관리자 검색 조회
     // 전체, 답변 대기, 답변 완료

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -153,17 +154,68 @@ public class InquiryServiceImpl implements InquiryService {
     }
 
 
-    // 이전 문의 조회
+    // 이전 문의 제목 조회
     @Override
-    public List<Inquiry> findPreviousInquiry(Long inquiryId) {
-        return inquiryRepository.findPreviousInquiry(inquiryId, PageRequest.of(0, 1));
+    public String findPreviousInquiryTitle(Long inquiryId) {
+        List<Inquiry> previousInquiryList = inquiryRepository.findPreviousInquiry(inquiryId, PageRequest.of(0, 1));
+
+        String previousInquiryTitle;
+        if (previousInquiryList.isEmpty()) {
+            previousInquiryTitle = null;
+        } else {
+            Inquiry previousInquiry = previousInquiryList.get(0);
+            previousInquiryTitle = previousInquiry.getInquiryTitle();
+        }
+
+        return previousInquiryTitle;
     }
 
-
-    // 다음 문의 조회
+    // 이전 문의 작성일 조회
     @Override
-    public List<Inquiry> findNextInquiry(Long inquiryId) {
-        return inquiryRepository.findNextInquiry(inquiryId, PageRequest.of(0, 1));
+    public LocalDateTime findPreviousInquiryWriteDate(Long inquiryId) {
+        List<Inquiry> previousInquiryList = inquiryRepository.findPreviousInquiry(inquiryId, PageRequest.of(0, 1));
+
+        LocalDateTime previousInquiryWriteDate;
+        if (previousInquiryList.isEmpty()) {
+            previousInquiryWriteDate = null;
+        } else {
+            Inquiry previousInquiry = previousInquiryList.get(0);
+            previousInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
+        }
+
+        return previousInquiryWriteDate;
+    }
+
+    // 다음 문의 제목 조회
+    @Override
+    public String findNextInquiryTitle(Long inquiryId) {
+        List<Inquiry> nextInquiryList = inquiryRepository.findNextInquiry(inquiryId, PageRequest.of(0, 1));
+
+        String nextInquiryTitle;
+        if (nextInquiryList.isEmpty()) {
+            nextInquiryTitle = null;
+        } else {
+            Inquiry previousInquiry = nextInquiryList.get(0);
+            nextInquiryTitle = previousInquiry.getInquiryTitle();
+        }
+
+        return nextInquiryTitle;
+    }
+
+    // 다음 문의 제목 조회
+    @Override
+    public LocalDateTime findNextInquiryWriteDate(Long inquiryId) {
+        List<Inquiry> nextInquiryList = inquiryRepository.findNextInquiry(inquiryId, PageRequest.of(0, 1));
+
+        LocalDateTime nextInquiryWriteDate;
+        if (nextInquiryList.isEmpty()) {
+            nextInquiryWriteDate = null;
+        } else {
+            Inquiry previousInquiry = nextInquiryList.get(0);
+            nextInquiryWriteDate = previousInquiry.getInquiryRegistrationDate();
+        }
+
+        return nextInquiryWriteDate;
     }
 
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryServiceImpl.java
@@ -152,6 +152,21 @@ public class InquiryServiceImpl implements InquiryService {
         return inquiryRepository.bulkDelete(inquiryIdList);
     }
 
+
+    // 이전 문의 조회
+    @Override
+    public List<Inquiry> findPreviousInquiry(Long inquiryId) {
+        return inquiryRepository.findPreviousInquiry(inquiryId, PageRequest.of(0, 1));
+    }
+
+
+    // 다음 문의 조회
+    @Override
+    public List<Inquiry> findNextInquiry(Long inquiryId) {
+        return inquiryRepository.findNextInquiry(inquiryId, PageRequest.of(0, 1));
+    }
+
+
     // 관리자 검색 조회
     // 전체, 답변 대기, 답변 완료
     // 검색 (전략명, 트레이더, 질문자)
@@ -159,6 +174,7 @@ public class InquiryServiceImpl implements InquiryService {
 
         return inquiryRepository.adminInquirySearchWithBooleanBuilder(inquiryAdminListShowRequestDto, PageRequest.of(page, 10));
     }
+
 
     // 문의자, 트레이더 검색 조회
     // 정렬 순 셀렉트 박스 (최신순, 전략명)

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
@@ -2,6 +2,7 @@ package com.be3c.sysmetic.domain.member.service;
 
 import com.be3c.sysmetic.domain.member.dto.NoticeAdminListShowRequestDto;
 import com.be3c.sysmetic.domain.member.dto.NoticeExistFileImageRequestDto;
+import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,4 +44,10 @@ public interface NoticeService {
     // 일반 검색 조회
     // 검색 (조건: 제목+내용)
     Page<Notice> findNotice(String searchText, Integer page);
+
+    // 이전글 조회
+    List<Notice> findPreviousNotice(Long noticeId);
+
+    // 다음글 조회
+    List<Notice> findNextNotice(Long noticeId);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public interface NoticeService {
 
     // 등록
-    boolean registerNotice(Long writerId, String noticeTitle, String noticeContent, Boolean isOpen,
+    boolean registerNotice(Long writerId, String noticeTitle, String noticeContent, Boolean isAttachment, Boolean isOpen,
                            List<MultipartFile> fileList, List<MultipartFile> imageList);
 
     // 관리자 검색 조회
@@ -29,7 +29,7 @@ public interface NoticeService {
     Notice findNoticeById(Long noticeId);
 
     // 관리자 문의 수정
-    boolean modifyNotice(Long noticeId, String noticeTitle, String noticeContent, Long correctorId, Boolean isOpen,
+    boolean modifyNotice(Long noticeId, String noticeTitle, String noticeContent, Long correctorId, Boolean isAttachment, Boolean isOpen,
                          List<NoticeExistFileImageRequestDto> existFileDtoList, List<NoticeExistFileImageRequestDto> existImageDtoList, List<MultipartFile> newFileList, List<MultipartFile> newImageList);
 
     // 관리자 문의 삭제
@@ -38,7 +38,7 @@ public interface NoticeService {
     // 관리자 문의 목록 삭제
     Map<Long, String> deleteAdminNoticeList(List<Long> noticeIdList);
 
-    // 회원 검색 조회
+    // 일반 검색 조회
     // 검색 (조건: 제목+내용)
     Page<Notice> findNotice(String searchText, Integer page);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
@@ -7,6 +7,7 @@ import com.be3c.sysmetic.domain.member.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -45,9 +46,15 @@ public interface NoticeService {
     // 검색 (조건: 제목+내용)
     Page<Notice> findNotice(String searchText, Integer page);
 
-    // 이전글 조회
-    List<Notice> findPreviousNotice(Long noticeId);
+    // 이전글 제목 조회
+    String findPreviousNoticeTitle(Long noticeId);
 
-    // 다음글 조회
-    List<Notice> findNextNotice(Long noticeId);
+    // 이전글 작성일 조회
+    LocalDateTime findPreviousNoticeWriteDate(Long noticeId);
+
+    // 다음글 제목 조회
+    String findNextNoticeTitle(Long noticeId);
+
+    // 다음글 제목 조회
+    LocalDateTime findNextNoticeWriteDate(Long noticeId);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
@@ -12,8 +12,9 @@ import java.util.Map;
 public interface NoticeService {
 
     // 등록
-    boolean registerNotice(Long writerId, String noticeTitle, String noticeContent, Boolean isAttachment, Boolean isOpen,
-                           List<MultipartFile> fileList, List<MultipartFile> imageList);
+    boolean registerNotice(Long writerId, String noticeTitle, String noticeContent,
+                           Boolean fileExists, Boolean imageExist, Boolean isOpen,
+                           List<MultipartFile> fileLists, List<MultipartFile> imageList);
 
     // 관리자 검색 조회
     // 검색 (사용: title, content, all, writer) (설명: 제목, 내용, 제목+내용, 작성자)
@@ -29,7 +30,8 @@ public interface NoticeService {
     Notice findNoticeById(Long noticeId);
 
     // 관리자 문의 수정
-    boolean modifyNotice(Long noticeId, String noticeTitle, String noticeContent, Long correctorId, Boolean isAttachment, Boolean isOpen,
+    boolean modifyNotice(Long noticeId, String noticeTitle, String noticeContent, Long correctorId,
+                         Boolean fileExists, Boolean imageExists, Boolean isOpen,
                          List<NoticeExistFileImageRequestDto> existFileDtoList, List<NoticeExistFileImageRequestDto> existImageDtoList, List<MultipartFile> newFileList, List<MultipartFile> newImageList);
 
     // 관리자 문의 삭제

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeServiceImpl.java
@@ -222,4 +222,18 @@ public class NoticeServiceImpl implements NoticeService {
 
         return noticeRepository.noticeSearchWithBooleanBuilder(searchText, PageRequest.of(page, 10));
     }
+
+
+    // 이전글 조회
+    @Override
+    public List<Notice> findPreviousNotice(Long noticeId) {
+        return noticeRepository.findPreviousNotice(noticeId, PageRequest.of(0, 1));
+    }
+
+
+    // 다음글 조회
+    @Override
+    public List<Notice> findNextNotice(Long noticeId) {
+        return noticeRepository.findNextNotice(noticeId, PageRequest.of(0, 1));
+    }
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.be3c.sysmetic.domain.member.service;
 
 import com.be3c.sysmetic.domain.member.dto.NoticeExistFileImageRequestDto;
+import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.Member;
 import com.be3c.sysmetic.domain.member.entity.Notice;
 import com.be3c.sysmetic.domain.member.repository.MemberRepository;
@@ -224,16 +225,67 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
 
-    // 이전글 조회
+    // 이전글 제목 조회
     @Override
-    public List<Notice> findPreviousNotice(Long noticeId) {
-        return noticeRepository.findPreviousNotice(noticeId, PageRequest.of(0, 1));
+    public String findPreviousNoticeTitle(Long noticeId) {
+        List<Notice> previousNoticeList = noticeRepository.findPreviousNotice(noticeId, PageRequest.of(0, 1));
+
+        String previousNoticeTitle;
+        if (previousNoticeList.isEmpty()) {
+            previousNoticeTitle = null;
+        } else {
+            Notice previousNotice = previousNoticeList.get(0);
+            previousNoticeTitle = previousNotice.getNoticeTitle();
+        }
+
+        return previousNoticeTitle;
     }
 
-
-    // 다음글 조회
+    // 이전글 작성일 조회
     @Override
-    public List<Notice> findNextNotice(Long noticeId) {
-        return noticeRepository.findNextNotice(noticeId, PageRequest.of(0, 1));
+    public LocalDateTime findPreviousNoticeWriteDate(Long noticeId) {
+        List<Notice> previousNoticeList = noticeRepository.findPreviousNotice(noticeId, PageRequest.of(0, 1));
+
+        LocalDateTime previousNoticeWriteDate;
+        if (previousNoticeList.isEmpty()) {
+            previousNoticeWriteDate = null;
+        } else {
+            Notice previousNotice = previousNoticeList.get(0);
+            previousNoticeWriteDate = previousNotice.getWriteDate();
+        }
+
+        return previousNoticeWriteDate;
+    }
+
+    // 다음글 제목 조회
+    @Override
+    public String findNextNoticeTitle(Long noticeId) {
+        List<Notice> nextNoticeList = noticeRepository.findNextNotice(noticeId, PageRequest.of(0, 1));
+
+        String nextNoticeTitle;
+        if (nextNoticeList.isEmpty()) {
+            nextNoticeTitle = null;
+        } else {
+            Notice previousNotice = nextNoticeList.get(0);
+            nextNoticeTitle = previousNotice.getNoticeTitle();
+        }
+
+        return nextNoticeTitle;
+    }
+
+    // 다음글 제목 조회
+    @Override
+    public LocalDateTime findNextNoticeWriteDate(Long noticeId) {
+        List<Notice> nextNoticeList = noticeRepository.findNextNotice(noticeId, PageRequest.of(0, 1));
+
+        LocalDateTime nextNoticeWriteDate;
+        if (nextNoticeList.isEmpty()) {
+            nextNoticeWriteDate = null;
+        } else {
+            Notice previousNotice = nextNoticeList.get(0);
+            nextNoticeWriteDate = previousNotice.getWriteDate();
+        }
+
+        return nextNoticeWriteDate;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,13 @@
 spring.application.name=sysmetic
 
 # JPA Setting
-spring.jpa.hibernate.ddl-auto=create
-#spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=false
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-spring.config.import=classpath:application-test.properties, cloud.properties, jwt.properties
-#spring.config.import=classpath:database.properties, cloud.properties, jwt.properties
+spring.config.import=classpath:database.properties, cloud.properties, jwt.properties
 
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=40MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,15 @@
 spring.application.name=sysmetic
 
 # JPA Setting
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
+#spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=false
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-spring.config.import=classpath:database.properties, cloud.properties, jwt.properties
+spring.config.import=classpath:application-test.properties, cloud.properties, jwt.properties
+#spring.config.import=classpath:database.properties, cloud.properties, jwt.properties
 
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=40MB

--- a/src/test/java/com/be3c/sysmetic/domain/member/service/LoginServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/service/LoginServiceTest.java
@@ -62,7 +62,7 @@ class LoginServiceImplTest {
         String email = "notfound@test.com";
         when(memberRepository.existsByEmail(email)).thenReturn(false);
 
-        // When & Then
+         When & Then
         assertThatThrownBy(() -> loginService.findEmail(email))
                 .isInstanceOf(MemberBadRequestException.class)
                 .hasMessage(MemberExceptionMessage.EX_1.getMessage());

--- a/src/test/java/com/be3c/sysmetic/domain/member/service/NoticeServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/service/NoticeServiceTest.java
@@ -67,7 +67,8 @@ class NoticeServiceTest {
                             .correctorId(member.getId())
                             .correctDate(LocalDateTime.now())
                             .hits(0L)
-                            .isAttachment(false)
+                            .fileExists(false)
+                            .imageExists(false)
                             .isOpen(isOpen)
                             .build();
                     noticeRepository.save(notice);
@@ -83,7 +84,7 @@ class NoticeServiceTest {
         Member member = createMember("닉네임");
 
         //when
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, false, new ArrayList<>(), new ArrayList<>());
         List<Notice> noticeList = noticeRepository.findByNoticeTitle("공지제목1");
         Notice notice = noticeList.get(0);
 
@@ -95,12 +96,12 @@ class NoticeServiceTest {
     public void 공지사항_수정() throws Exception {
         //given
         Member member = createMember("닉네임");
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, false, new ArrayList<>(), new ArrayList<>());
 
         //when
         List<Notice> noticeList = noticeRepository.findByNoticeTitle("공지제목1");
         Notice notice = noticeList.get(0);
-        noticeService.modifyNotice(notice.getId(), "수정공지제목1", "수정공지내용1", 10L, false, false, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        noticeService.modifyNotice(notice.getId(), "수정공지제목1", "수정공지내용1", 10L, false, false, false, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
 
         //then
         assertEquals("수정공지제목1", notice.getNoticeTitle());
@@ -112,7 +113,7 @@ class NoticeServiceTest {
     public void 공지사항_공개여부_수정() throws Exception {
         //given
         Member member = createMember("닉네임");
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, false, new ArrayList<>(), new ArrayList<>());
 
         //when
         List<Notice> noticeList = noticeRepository.findByNoticeTitle("공지제목1");
@@ -127,11 +128,11 @@ class NoticeServiceTest {
     public void 공지사항_검색() throws Exception {
         //given
         Member member = createMember("닉네임");
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목2", "공지내용2", false, false, new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목3", "공지내용3", false, false, new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목4", "공지내용4", false, false, new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목5", "공지내용5", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목2", "공지내용2", false, false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목3", "공지내용3", false, false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목4", "공지내용4", false, false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목5", "공지내용5", false, false, false, new ArrayList<>(), new ArrayList<>());
 
         //when
         int page = 1;

--- a/src/test/java/com/be3c/sysmetic/domain/member/service/NoticeServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/service/NoticeServiceTest.java
@@ -83,7 +83,7 @@ class NoticeServiceTest {
         Member member = createMember("닉네임");
 
         //when
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
         List<Notice> noticeList = noticeRepository.findByNoticeTitle("공지제목1");
         Notice notice = noticeList.get(0);
 
@@ -95,12 +95,12 @@ class NoticeServiceTest {
     public void 공지사항_수정() throws Exception {
         //given
         Member member = createMember("닉네임");
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
 
         //when
         List<Notice> noticeList = noticeRepository.findByNoticeTitle("공지제목1");
         Notice notice = noticeList.get(0);
-        noticeService.modifyNotice(notice.getId(), "수정공지제목1", "수정공지내용1", 10L, false, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        noticeService.modifyNotice(notice.getId(), "수정공지제목1", "수정공지내용1", 10L, false, false, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
 
         //then
         assertEquals("수정공지제목1", notice.getNoticeTitle());
@@ -112,7 +112,7 @@ class NoticeServiceTest {
     public void 공지사항_공개여부_수정() throws Exception {
         //given
         Member member = createMember("닉네임");
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
 
         //when
         List<Notice> noticeList = noticeRepository.findByNoticeTitle("공지제목1");
@@ -127,11 +127,11 @@ class NoticeServiceTest {
     public void 공지사항_검색() throws Exception {
         //given
         Member member = createMember("닉네임");
-        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false,  new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목2", "공지내용2", false,  new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목3", "공지내용3", false,  new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목4", "공지내용4", false,  new ArrayList<>(), new ArrayList<>());
-        noticeService.registerNotice(member.getId(), "공지제목5", "공지내용5", false,  new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목1", "공지내용1", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목2", "공지내용2", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목3", "공지내용3", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목4", "공지내용4", false, false, new ArrayList<>(), new ArrayList<>());
+        noticeService.registerNotice(member.getId(), "공지제목5", "공지내용5", false, false, new ArrayList<>(), new ArrayList<>());
 
         //when
         int page = 1;


### PR DESCRIPTION
# 🚀 Pull Request

문의, 공지사항 상세 페이지 에러 발생 수정

## #️⃣ 연관된 이슈

#187

## 📋 작업 내용

문의, 공지사항 상세 페이지 이전글 다음글 없으면 404 발생
-> 없으면 이전글 다음글 제목, 작성일 null이 반환되게 수정
문의 상세 페이지 답변이 없으면 401 발생
-> 답변이 없으면 null이 반환되게 수정
공지사항 상세 반환 수정, 엔티티 fileExists, imageExists로 수정