### PR TITLE
refactor: 디폴트 프로필 이미지 기능, 엑셀 양식 다운로드 기능 구현 및 리팩토링  #111

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/ExcelController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/ExcelController.java
@@ -14,6 +14,31 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ExcelController {
 
     @Operation(
+            summary = "엑셀 파일 양식 URL 조회",
+            description = "엑셀 파일 양식 URL을 반환합니다. 이 URL을 사용하여 엑셀 파일을 다운로드할 수 있습니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "엑셀 파일 양식 URL 반환 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = APIResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 오류",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = APIResponse.class)
+                            )
+                    )
+            }
+    )
+    @GetMapping("/daily")
+    ResponseEntity<APIResponse<String>> getExcelExample();
+
+    @Operation(
             summary = "엑셀 파일 업로드",
             description = "전략 ID에 해당하는 일간 데이터를 엑셀 파일로 업로드하여 저장합니다. " +
                     "Excel 2007 이상의 .xlsx만 가능하며, 한 개의 시트만 읽습니다. " +

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/ExcelControllerImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/ExcelControllerImpl.java
@@ -18,6 +18,17 @@ public class ExcelControllerImpl implements ExcelController {
     final ExcelService excelService;
 
     @Override
+    @GetMapping("/daily")
+    public ResponseEntity<APIResponse<String>> getExcelExample() {
+
+        String url = excelService.getExcelFormUrl();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(APIResponse.success(url));
+    }
+
+    @Override
     @PostMapping("/daily/{strategyId}")
     public ResponseEntity<APIResponse<String>> uploadExcel(
             @RequestParam("file") MultipartFile file,

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/ExcelService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/ExcelService.java
@@ -5,6 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.InputStream;
 
 public interface ExcelService {
+    String getExcelFormUrl();
     void uploadExcel(MultipartFile file, Long strategyId);
     InputStream downloadDailyExcel(Long strategyId);
     InputStream downloadDailyExcelWithStatistics(Long strategyId);

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/ExcelServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/ExcelServiceImpl.java
@@ -10,10 +10,12 @@ import com.be3c.sysmetic.domain.strategy.repository.StrategyRepository;
 import com.be3c.sysmetic.domain.strategy.util.DoubleHandler;
 import com.be3c.sysmetic.domain.strategy.util.StrategyCalculator;
 import com.be3c.sysmetic.global.util.file.exception.InvalidFileFormatException;
+import com.be3c.sysmetic.global.util.file.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.apache.poi.EmptyFileException;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,6 +34,15 @@ public class ExcelServiceImpl implements ExcelService {
     final StrategyRepository strategyRepository;
     final DoubleHandler doubleHandler;
     final StrategyCalculator strategyCalculator;
+    final S3Service s3Service;
+
+    @Value("${daily.excel.form.key}")
+    private String excelFormKey;
+
+    @Override
+    public String getExcelFormUrl(){
+        return s3Service.createPresignedGetUrl(excelFormKey);
+    }
 
     /**
      * 엑셀 파일을 읽어서 일간 데이터를 DB에 저장

--- a/src/main/java/com/be3c/sysmetic/global/util/file/repository/FileRepository.java
+++ b/src/main/java/com/be3c/sysmetic/global/util/file/repository/FileRepository.java
@@ -1,21 +1,10 @@
 package com.be3c.sysmetic.global.util.file.repository;
 
-import com.be3c.sysmetic.global.util.file.dto.FileRequest;
 import com.be3c.sysmetic.global.util.file.entity.File;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface FileRepository extends JpaRepository<File, Long> {
-
-    @Query("SELECT f " +
-            "FROM File f " +
-            "WHERE f.referenceId = :#{#fileRequest.referenceId} " +
-            "AND f.referenceType = :#{#fileRequest.referenceType} " +
-            "ORDER BY f.referenceId")
-    List<File> findFilesByFileReference(@Param("fileRequest") FileRequest fileRequest);
-}
+public interface FileRepository extends JpaRepository<File, Long>, FileRepositoryCustom {}

--- a/src/main/java/com/be3c/sysmetic/global/util/file/repository/FileRepositoryCustom.java
+++ b/src/main/java/com/be3c/sysmetic/global/util/file/repository/FileRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.be3c.sysmetic.global.util.file.repository;
+
+import com.be3c.sysmetic.global.util.file.dto.FileRequest;
+import com.be3c.sysmetic.global.util.file.entity.File;
+
+import java.util.List;
+
+public interface FileRepositoryCustom {
+    List<File> findFilesByFileReference(FileRequest fileRequest);
+}

--- a/src/main/java/com/be3c/sysmetic/global/util/file/repository/FileRepositoryCustomImpl.java
+++ b/src/main/java/com/be3c/sysmetic/global/util/file/repository/FileRepositoryCustomImpl.java
@@ -1,0 +1,30 @@
+package com.be3c.sysmetic.global.util.file.repository;
+
+import com.be3c.sysmetic.global.util.file.dto.FileRequest;
+import com.be3c.sysmetic.global.util.file.entity.File;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.be3c.sysmetic.global.util.file.entity.QFile.file;
+
+@Repository
+@RequiredArgsConstructor
+public class FileRepositoryCustomImpl implements FileRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<File> findFilesByFileReference(FileRequest fileRequest) {
+
+        return queryFactory
+                .select(file)
+                .from(file)
+                .where(file.referenceId.eq(fileRequest.referenceId())
+                        .and(file.referenceType.eq(fileRequest.referenceType())))
+                .orderBy(file.id.asc())
+                .fetch();
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

**[디폴트 프로필 이미지 기능, 엑셀 양식 다운로드 기능 구현 및 리팩토링]**

## #️⃣ 연관된 이슈

#111

## 📋 작업 내용

1. 디폴트 프로필 이미지 기능 추가
- 프로필 이미지가 등록되지 않았을 때 기본 프로필 이미지를 사용하도록 기능을 추가했습니다.
2. 엑셀 양식 다운로드 기능 추가
- 엑셀 파일 양식 다운로드 기능을 추가하여 사용자들이 지정된 양식을 다운로드할 수 있게 했습니다.
3. JPQL 쿼리 리팩토링
- 기존 JPQL 쿼리를 QueryDSL로 변경하여 코드 안정성을 높이고, 쿼리 작성 시 발생할 수 있는 실수를 방지했습니다.
