### PR TITLE
feat: 파일을 찾지 못해도 예외를 던지지 않는 메서드 추가 #111

### DIFF
--- a/src/main/java/com/be3c/sysmetic/global/util/file/service/FileService.java
+++ b/src/main/java/com/be3c/sysmetic/global/util/file/service/FileService.java
@@ -38,6 +38,13 @@ public interface FileService {
     String getFilePath(FileRequest fileRequest);
 
     /**
+     * presignedUrl 혹은 null 반환
+     * @param fileRequest ReferenceType(참조 테이블명)과 ReferenceId(참조 id) 입력
+     * @return 파일 url 혹은 null
+     */
+    String getFilePathNullable(FileRequest fileRequest);
+
+    /**
      * presignedUrl 리스트 제공
      * @param fileRequest ReferenceType(참조 테이블명)과 ReferenceId(참조 id) 입력
      * @return 파일 url 리스트

--- a/src/main/java/com/be3c/sysmetic/global/util/file/service/FileServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/global/util/file/service/FileServiceImpl.java
@@ -6,7 +6,6 @@ import com.be3c.sysmetic.global.util.file.dto.FileWithInfoResponse;
 import com.be3c.sysmetic.global.util.file.entity.File;
 import com.be3c.sysmetic.global.util.file.exception.*;
 import com.be3c.sysmetic.global.util.file.repository.FileRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,7 +37,7 @@ public class FileServiceImpl implements FileService {
      */
 
     @Override
-    public void uploadImage(MultipartFile file, @Valid FileRequest fileRequest) {
+    public void uploadImage(MultipartFile file, FileRequest fileRequest) {
 
         checkFileSize(file);
         checkFileExtension(file, List.of("jpeg", "png", "gif"));
@@ -49,7 +48,7 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
-    public void uploadPdf(MultipartFile file, @Valid FileRequest fileRequest) {
+    public void uploadPdf(MultipartFile file, FileRequest fileRequest) {
 
         checkFileSize(file);
         checkFileExtension(file, List.of("pdf"));
@@ -60,7 +59,7 @@ public class FileServiceImpl implements FileService {
 
     @Transactional
     @Override
-    public void uploadAnyFile(MultipartFile file, @Valid FileRequest fileRequest) {
+    public void uploadAnyFile(MultipartFile file, FileRequest fileRequest) {
 
         checkFileSize(file);
 
@@ -92,7 +91,7 @@ public class FileServiceImpl implements FileService {
 
 
     @Override
-    public String getFilePath(@Valid FileRequest fileRequest) {
+    public String getFilePath(FileRequest fileRequest) {
 
         String key;
         List<File> files = fileRepository.findFilesByFileReference(fileRequest);
@@ -115,7 +114,22 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
-    public List<String> getFilePaths(@Valid FileRequest fileRequest) {
+    public String getFilePathNullable(FileRequest fileRequest){
+
+        List<File> files = fileRepository.findFilesByFileReference(fileRequest);
+
+        if (files.isEmpty()) {
+            return null;
+        } else {
+            if(files.size()>1)
+                log.warn("파일이 한 개가 아닙니다. 파일 참조 정보: {}", fileRequest);
+
+            return s3Service.createPresignedGetUrl(files.get(0).getPath());
+        }
+    }
+
+    @Override
+    public List<String> getFilePaths(FileRequest fileRequest) {
 
         List<File> files = fileRepository.findFilesByFileReference(fileRequest);
         checkFilesNotEmpty(files, fileRequest);
@@ -128,7 +142,7 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
-    public List<FileWithInfoResponse> getFileWithInfos(@Valid FileRequest fileRequest) {
+    public List<FileWithInfoResponse> getFileWithInfos(FileRequest fileRequest) {
 
         List<File> files = fileRepository.findFilesByFileReference(fileRequest);
         checkFilesNotEmpty(files, fileRequest);
@@ -155,7 +169,7 @@ public class FileServiceImpl implements FileService {
 
     @Transactional
     @Override
-    public void updateImage(MultipartFile file,@Valid FileRequest fileRequest) {
+    public void updateImage(MultipartFile file, FileRequest fileRequest) {
 
         checkFileSize(file);
         checkFileExtension(file, List.of("jpeg", "png", "gif"));
@@ -166,7 +180,7 @@ public class FileServiceImpl implements FileService {
 
     @Transactional
     @Override
-    public void updatePdf(MultipartFile file,@Valid FileRequest fileRequest) {
+    public void updatePdf(MultipartFile file, FileRequest fileRequest) {
 
         checkFileSize(file);
         checkFileExtension(file, List.of("pdf"));
@@ -176,7 +190,7 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
-    public void updateAnyFile(MultipartFile file,@Valid FileRequest fileRequest) {
+    public void updateAnyFile(MultipartFile file, FileRequest fileRequest) {
 
         checkFileSize(file);
 
@@ -243,7 +257,7 @@ public class FileServiceImpl implements FileService {
   */
 
     @Override
-    public boolean deleteFile(@Valid FileRequest fileRequest) {
+    public boolean deleteFile( FileRequest fileRequest) {
 
         List<File> files = fileRepository.findFilesByFileReference(fileRequest);
         if (files.isEmpty()) {
@@ -271,7 +285,7 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
-    public boolean deleteFiles(@Valid FileRequest fileRequest) {
+    public boolean deleteFiles( FileRequest fileRequest) {
 
         List<File> files = fileRepository.findFilesByFileReference(fileRequest);
 
@@ -325,7 +339,7 @@ public class FileServiceImpl implements FileService {
      * @param fileRequest 파일을 사용할 곳의 정보
      *                    referenceType 참조할 테이블명 referenceId 참조id
      */
-    private void fileEntityBuilderAndSaver(MultipartFile file, String s3KeyName, @Valid FileRequest fileRequest) {
+    private void fileEntityBuilderAndSaver(MultipartFile file, String s3KeyName, FileRequest fileRequest) {
         try {
             File fileEntity = File.builder()
                     .path(s3KeyName)
@@ -367,7 +381,7 @@ public class FileServiceImpl implements FileService {
         }
     }
 
-    private void checkFilesNotEmpty(List<File> files,@Valid FileRequest fileRequest){
+    private void checkFilesNotEmpty(List<File> files, FileRequest fileRequest){
         if (files.isEmpty()) {
             log.error("파일이 비어 있습니다. 파일 참조 정보: {}", fileRequest);
             throw new InvalidFileFormatException("파일이 비어 있습니다.");


### PR DESCRIPTION
# 🚀 Pull Request

**[파일을 찾지 못해도 예외를 던지지 않는 메서드 추가]**

## #️⃣ 연관된 이슈

#111

## 📋 작업 내용

- 파일을 찾지 못했을 때 예외를 던지지 않고 `null`을 반환하는 메서드를 추가하여, 파일이 없을 경우 더 유연하게 처리할 수 있도록 개선