### PR TITLE
fix: 일간분석 중복 등록 이슈 해결

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/controller/TraderStrategyController.java
@@ -97,8 +97,8 @@ public class TraderStrategyController {
             @PathVariable Long strategyId,
             @Valid @RequestBody List<DailyRequestDto> requestDtoList
     ) {
-        DailyPostResponseDto responseDto = dailyService.getIsDuplicate(strategyId, requestDtoList);
         dailyService.saveDaily(strategyId, requestDtoList);
+        DailyPostResponseDto responseDto = dailyService.getIsDuplicate(strategyId, requestDtoList);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(APIResponse.success(responseDto));

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/DailyServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/DailyServiceImpl.java
@@ -253,6 +253,10 @@ public class DailyServiceImpl implements DailyService {
             // 일간분석 등록이면서 이미 존재하는 일자일 경우 미저장
             if(dailyId == null && existingDaily != null) continue;
 
+            if(dailyList.stream().map(daily -> daily.getDate()).toList().contains(requestDto.getDate())) {
+                continue;
+            }
+
             if(dailyList.isEmpty()) {
                 if(beforeDaily == null) {
                     // DB 데이터 미존재


### PR DESCRIPTION
# 🚀 Pull Request

일간분석 중복 등록 이슈 해결

## #️⃣ 연관된 이슈

#229 

## 📋 작업 내용

일간분석 중복 등록시 2개의 데이터가 모두 저장되거나, 400 에러가 뜨는 이슈 해결
