### PR TITLE
update: 전략 기본 정보 수정 - 반려 상태 추가

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/strategy/dto/StrategyStatusCode.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/dto/StrategyStatusCode.java
@@ -9,7 +9,7 @@ public enum StrategyStatusCode {
     PRIVATE("PRIVATE"),
     PUBLIC("PUBLIC"),
     REQUEST("REQUEST"),
-    REJECTED("REJECTED"),
+    RETURN("RETURN"),
     NOT_USING_STATE("NOT_USING_STATE");
 
     String code;

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/AdminStrategyServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/AdminStrategyServiceImpl.java
@@ -111,7 +111,7 @@ public class AdminStrategyServiceImpl implements AdminStrategyService {
 
         strategyApproval.setStatusCode(Code.APPROVE_REJECT.getCode());
         strategyApproval.setRejectReason(rejectStrategyApprovalDto.getRejectReason());
-        strategyApproval.getStrategy().setStatusCode(StrategyStatusCode.REJECTED.getCode());
+        strategyApproval.getStrategy().setStatusCode(StrategyStatusCode.RETURN.getCode());
 
         strategyApprovalRepository.save(strategyApproval);
 

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/service/TraderStrategyServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/service/TraderStrategyServiceImpl.java
@@ -166,9 +166,10 @@ public class TraderStrategyServiceImpl implements TraderStrategyService {
         }
     }
 
-    // 상태 검증 - 비공개 상태만 기본정보 수정 가능
+    // 상태 검증
     private void checkStatus(String status) {
-        if(!status.equals(StrategyStatusCode.PRIVATE.name())) {
+        if(!status.equals(StrategyStatusCode.PRIVATE.name()) && !status.equals(StrategyStatusCode.RETURN.name())) {
+            // 비공개 상태가 아니고, 반려 상태가 아닐 경우 수정 불가
             throw new StrategyBadRequestException(StrategyExceptionMessage.INVALID_STATUS.getMessage(), ErrorCode.DISABLED_DATA_STATUS);
         }
     }


### PR DESCRIPTION
# 🚀 Pull Request

전략 기본 정보 수정 가능한 상태 - 비공개, 반려

## #️⃣ 연관된 이슈

#273 

## 📋 작업 내용

기존 비공개 상태일 경우에만 전략 기본 정보 수정이 가능했으나
반려 상태일 경우에도 수정 가능하도록 변경했습니다.
