### PR TITLE
Update: 문의 페이지에서 공개 상태 전략 외에는 '조회할 수 없는 전략'이라고 뜨게 수정 #278

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
@@ -263,7 +263,7 @@ public class InquiryController implements InquiryControllerDocs {
 
 
     /*
-        질문자 문의 조회 / 검색 API
+        질문자 문의 조회 API
         1. 사용자 인증 정보가 없음 : FORBIDDEN
         2. 문의 데이터 조회에 성공했을 때 : OK
         3. 파라미터 데이터의 형식이 올바르지 않음 : BAD_REQUEST
@@ -292,28 +292,17 @@ public class InquiryController implements InquiryControllerDocs {
                     .body(APIResponse.fail(ErrorCode.BAD_REQUEST, "쿼리 파라미터 sort가 올바르지 않습니다."));
         }
 
-        Long userId = securityUtils.getUserIdInSecurityContext();
+        try {
 
-        InquiryListShowRequestDto inquiryListShowRequestDto = new InquiryListShowRequestDto();
-        inquiryListShowRequestDto.setInquirerId(userId);
-        inquiryListShowRequestDto.setSort(sort);
-        inquiryListShowRequestDto.setTab(inquiryStatus);
+            PageResponse<InquiryListOneShowResponseDto> inquiryPage = inquiryService.showInquirerInquiry(page, sort, inquiryStatus);
 
-        Page<Inquiry> inquiryList = inquiryService.findInquiries(inquiryListShowRequestDto, page);
-
-        List<InquiryListOneShowResponseDto> inquiryDtoList = inquiryList.stream()
-                .map(inquiryService::inquiryToInquiryOneResponseDto).collect(Collectors.toList());
-
-        PageResponse<InquiryListOneShowResponseDto> inquiryPage = PageResponse.<InquiryListOneShowResponseDto>builder()
-                .currentPage(page)
-                .pageSize(pageSize)
-                .totalElement(inquiryList.getTotalElements())
-                .totalPages(inquiryList.getTotalPages())
-                .content(inquiryDtoList)
-                .build();
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(APIResponse.success(inquiryPage));
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(APIResponse.success(inquiryPage));
+        }
+        catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(APIResponse.fail(ErrorCode.BAD_REQUEST));
+        }
     }
 
 
@@ -568,28 +557,17 @@ public class InquiryController implements InquiryControllerDocs {
                     .body(APIResponse.fail(ErrorCode.BAD_REQUEST, "쿼리 파라미터 sort가 올바르지 않습니다."));
         }
 
-        Long userId = securityUtils.getUserIdInSecurityContext();
+        try {
 
-        InquiryListShowRequestDto inquiryListShowRequestDto = new InquiryListShowRequestDto();
-        inquiryListShowRequestDto.setTraderId(userId);
-        inquiryListShowRequestDto.setSort(sort);
-        inquiryListShowRequestDto.setTab(inquiryStatus);
+            PageResponse<InquiryListOneShowResponseDto> inquiryPage = inquiryService.showTraderInquiry(page, sort, inquiryStatus);
 
-        Page<Inquiry> inquiryList = inquiryService.findInquiries(inquiryListShowRequestDto, page);
-
-        List<InquiryListOneShowResponseDto> inquiryDtoList = inquiryList.stream()
-                .map(inquiryService::inquiryToInquiryOneResponseDto).collect(Collectors.toList());
-
-        PageResponse<InquiryListOneShowResponseDto> inquiryPage = PageResponse.<InquiryListOneShowResponseDto>builder()
-                .currentPage(page)
-                .pageSize(pageSize)
-                .totalElement(inquiryList.getTotalElements())
-                .totalPages(inquiryList.getTotalPages())
-                .content(inquiryDtoList)
-                .build();
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(APIResponse.success(inquiryPage));
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(APIResponse.success(inquiryPage));
+        }
+        catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(APIResponse.fail(ErrorCode.BAD_REQUEST));
+        }
     }
 
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryControllerDocs.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryControllerDocs.java
@@ -211,10 +211,10 @@ public interface InquiryControllerDocs {
             @RequestBody InquirySaveRequestDto inquirySaveRequestDto);
 
 
-    // 질문자 문의 조회 / 검색 API
+    // 질문자 문의 조회 API
     @Operation(
-            summary = "질문자 문의 조회 / 검색",
-            description = "질문자가 자신의 문의를 조회하거나 검색하는 API"
+            summary = "질문자 문의 조회",
+            description = "질문자가 자신의 문의를 조회하는 API"
     )
     @ApiResponses({
             @ApiResponse(

--- a/src/main/java/com/be3c/sysmetic/domain/member/exception/MemberExceptionMessage.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/exception/MemberExceptionMessage.java
@@ -25,8 +25,6 @@ public enum MemberExceptionMessage {
     // 이메일 관련 오류
     ERROR_EMAIL("이메일 관련 오류 발생"),
 
-    // 로그인한 사람이 권한이 없는 글에 접근할 때
-    INVALID_MEMBER("유효하지 않은 회원입니다.");
     ;
 
     private final String message;

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryCustom.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryCustom.java
@@ -6,9 +6,13 @@ import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface InquiryRepositoryCustom {
 
     Page<Inquiry> adminInquirySearchWithBooleanBuilder(InquiryAdminListShowRequestDto inquiryAdminListShowRequestDto, Pageable pageable);
 
-    Page<Inquiry> inquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto, Pageable pageable);
+    Page<Inquiry> pageInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto, Pageable pageable);
+
+    List<Inquiry> listInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryImpl.java
@@ -26,6 +26,7 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
     private final JPAQueryFactory jpaQueryFactory1;
     private final JPAQueryFactory jpaQueryFactory2;
+    private final JPAQueryFactory jpaQueryFactory3;
     private final QInquiry inquiry = QInquiry.inquiry;
 
     public Page<Inquiry> adminInquirySearchWithBooleanBuilder(InquiryAdminListShowRequestDto inquiryAdminListShowRequestDto, Pageable pageable) {
@@ -70,38 +71,74 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
     }
 
 
-    public Page<Inquiry> inquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto, Pageable pageable) {
+    public Page<Inquiry> pageInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto, Pageable pageable) {
 
         BooleanBuilder predicate = new BooleanBuilder();
-        BooleanBuilder predicate1 = new BooleanBuilder();
-        BooleanBuilder predicate2 = new BooleanBuilder();
 
         Long inquirerId = inquiryListShowRequestDto.getInquirerId();
         Long traderId = inquiryListShowRequestDto.getTraderId();
-        String sort = inquiryListShowRequestDto.getSort();
         InquiryStatus tab = inquiryListShowRequestDto.getTab();
 
         // 질문자 별
         if (inquirerId != null) {
             predicate.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 트레이더 별
+        if (traderId != null) {
+            predicate.and(inquiry.traderId.eq(traderId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (tab.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(tab));
+        } else if (tab.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(tab));
+        }
+
+        List<Inquiry> content = new ArrayList<>();
+        long total;
+
+        QueryResults<Inquiry> results = jpaQueryFactory
+                .selectFrom(inquiry)
+                .where(predicate)
+                .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+
+        content = results.getResults();
+        total = results.getTotal();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    public List<Inquiry> listInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto) {
+
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquirerId = inquiryListShowRequestDto.getInquirerId();
+        Long traderId = inquiryListShowRequestDto.getTraderId();
+        InquiryStatus tab = inquiryListShowRequestDto.getTab();
+
+        // 질문자 별
+        if (inquirerId != null) {
             predicate1.and(inquiry.inquirer.id.eq(inquirerId));
             predicate2.and(inquiry.inquirer.id.eq(inquirerId));
         }
 
         // 트레이더 별
         if (traderId != null) {
-            predicate.and(inquiry.traderId.eq(traderId));
             predicate1.and(inquiry.traderId.eq(traderId));
             predicate2.and(inquiry.traderId.eq(traderId));
         }
 
         // 전체, 답변 대기, 답변 완료
         if (tab.equals(InquiryStatus.unclosed)) {
-            predicate.and(inquiry.inquiryStatus.eq(tab));
             predicate1.and(inquiry.inquiryStatus.eq(tab));
             predicate2.and(inquiry.inquiryStatus.eq(tab));
         } else if (tab.equals(InquiryStatus.closed)) {
-            predicate.and(inquiry.inquiryStatus.eq(tab));
             predicate1.and(inquiry.inquiryStatus.eq(tab));
             predicate2.and(inquiry.inquiryStatus.eq(tab));
         }
@@ -110,47 +147,20 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
         predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()).not());
 
         List<Inquiry> content = new ArrayList<>();
-        long total;
-        // 정렬순 별
-        if (sort.equals("registrationDate")) {
-            QueryResults<Inquiry> results = jpaQueryFactory
-                    .selectFrom(inquiry)
-                    .where(predicate)
-                    .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetchResults();
+        List<Inquiry> results1 = jpaQueryFactory1
+                .selectFrom(inquiry)
+                .where(predicate1)
+                .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+        List<Inquiry> results2 = jpaQueryFactory2
+                .selectFrom(inquiry)
+                .where(predicate2)
+                .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
 
-            content = results.getResults();
-            total = results.getTotal();
+        content.addAll(results1);
+        content.addAll(results2);
 
-        } else if (sort.equals("strategyName")) {
-            QueryResults<Inquiry> results1 = jpaQueryFactory1
-                    .selectFrom(inquiry)
-                    .where(predicate1)
-                    .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetchResults();
-            QueryResults<Inquiry> results2 = jpaQueryFactory2
-                    .selectFrom(inquiry)
-                    .where(predicate2)
-                    .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetchResults();
-
-            List<Inquiry> content1 = results1.getResults();
-            List<Inquiry> content2 = results2.getResults();
-            content.addAll(content1);
-            content.addAll(content2);
-            long total1 = results1.getTotal();
-            long total2 = results2.getTotal();
-            total = total1 + total2;
-        } else {
-            throw new IllegalArgumentException("정렬순을 지정하세요");
-        }
-
-        return new PageImpl<>(content, pageable, total);
+        return content;
     }
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.be3c.sysmetic.domain.member.dto.InquiryListShowRequestDto;
 import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
 import com.be3c.sysmetic.domain.member.entity.QInquiry;
+import com.be3c.sysmetic.domain.strategy.dto.StrategyStatusCode;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -46,7 +47,7 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
         if (StringUtils.hasText(searchText)) {
             if (searchType.equals("strategy")) {
                 predicate.and(inquiry.strategy.name.contains(searchText));
-                predicate.and(inquiry.strategy.statusCode.eq("NOT_USING_STATE").not());
+                predicate.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
             } else if (searchType.equals("trader")) {
                 predicate.and(inquiry.strategy.trader.nickname.contains(searchText));
             } else if (searchType.equals("inquirer")) {
@@ -105,8 +106,8 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
             predicate2.and(inquiry.inquiryStatus.eq(tab));
         }
 
-        predicate1.and(inquiry.strategy.statusCode.eq("NOT_USING_STATE").not());
-        predicate2.and(inquiry.strategy.statusCode.eq("NOT_USING_STATE"));
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()).not());
 
         List<Inquiry> content = new ArrayList<>();
         long total;

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
@@ -4,6 +4,7 @@ import com.be3c.sysmetic.domain.member.dto.*;
 import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
 import com.be3c.sysmetic.domain.strategy.entity.Strategy;
+import com.be3c.sysmetic.global.common.response.PageResponse;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -37,20 +38,25 @@ public interface InquiryService {
     // 검색 (전략명, 트레이더, 질문자)
     Page<Inquiry> findInquiriesAdmin(InquiryAdminListShowRequestDto inquiryAdminListShowRequestDto, Integer page);
 
-    // 문의자, 트레이더 검색 조회
-    // 정렬 순 셀렉트 박스 (최신순, 전략명)
-    // 답변상태 셀렉트 박스 (전체, 답변 대기, 답변 완료)
-    Page<Inquiry> findInquiries(InquiryListShowRequestDto inquiryListShowRequestDto, Integer page);
-
     InquiryAdminListOneShowResponseDto inquiryToInquiryAdminOneResponseDto(Inquiry inquiry);
 
     InquiryAnswerAdminShowResponseDto inquiryIdToInquiryAnswerAdminShowResponseDto (Long inquiryId, Integer page, String closed, String searchType, String searchText);
 
-    InquirySavePageShowResponseDto strategyToInquirySavePageShowResponseDto(Strategy strategy);
-
     InquiryListOneShowResponseDto inquiryToInquiryOneResponseDto(Inquiry inquiry);
+
+    InquirySavePageShowResponseDto strategyToInquirySavePageShowResponseDto(Strategy strategy);
 
     InquiryAnswerInquirerShowResponseDto inquiryIdToInquiryAnswerInquirerShowResponseDto(Long inquiryId, Integer page, String sort, String closed);
 
     InquiryAnswerTraderShowResponseDto inquiryIdToInquiryAnswerTraderShowResponseDto(Long inquiryId, Integer page, String sort, String closed);
+
+    // 문의자 검색 조회
+    // 정렬 순 셀렉트 박스 (최신순, 전략명)
+    // 답변상태 셀렉트 박스 (전체, 답변 대기, 답변 완료)
+    PageResponse<InquiryListOneShowResponseDto> showInquirerInquiry(Integer page, String sort, InquiryStatus inquiryStatus);
+
+    // 트레이더 검색 조회
+    // 정렬 순 셀렉트 박스 (최신순, 전략명)
+    // 답변상태 셀렉트 박스 (전체, 답변 대기, 답변 완료)
+    PageResponse<InquiryListOneShowResponseDto> showTraderInquiry(Integer page, String sort, InquiryStatus inquiryStatus);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryServiceImpl.java
@@ -11,6 +11,7 @@ import com.be3c.sysmetic.domain.member.repository.InquiryAnswerRepository;
 import com.be3c.sysmetic.domain.member.repository.InquiryRepository;
 import com.be3c.sysmetic.domain.member.repository.MemberRepository;
 import com.be3c.sysmetic.domain.strategy.dto.StockListDto;
+import com.be3c.sysmetic.domain.strategy.dto.StrategyStatusCode;
 import com.be3c.sysmetic.domain.strategy.entity.Strategy;
 import com.be3c.sysmetic.domain.strategy.repository.StrategyRepository;
 import com.be3c.sysmetic.domain.strategy.util.StockGetter;
@@ -191,7 +192,7 @@ public class InquiryServiceImpl implements InquiryService {
         String strategyName;
         String statusCode;
 
-        if (!Objects.equals(inquiry.getStrategy().getStatusCode(), "NOT_USING_STATE")) {
+        if (Objects.equals(inquiry.getStrategy().getStatusCode(), StrategyStatusCode.PUBLIC.getCode())) {
             methodId = inquiry.getStrategy().getMethod().getId();
             methodIconPath = fileService.getFilePathNullable(new FileRequest(FileReferenceType.METHOD, methodId));
             cycle = inquiry.getStrategy().getCycle();
@@ -291,7 +292,7 @@ public class InquiryServiceImpl implements InquiryService {
         String strategyName;
         String statusCode;
 
-        if (!Objects.equals(inquiry.getStrategy().getStatusCode(), "NOT_USING_STATE")) {
+        if (Objects.equals(inquiry.getStrategy().getStatusCode(), StrategyStatusCode.PUBLIC.getCode())) {
             methodId = inquiry.getStrategy().getMethod().getId();
             methodIconPath = fileService.getFilePathNullable(new FileRequest(FileReferenceType.METHOD, methodId));
             cycle = inquiry.getStrategy().getCycle();
@@ -389,7 +390,7 @@ public class InquiryServiceImpl implements InquiryService {
         String strategyName;
         String statusCode;
 
-        if (!Objects.equals(inquiry.getStrategy().getStatusCode(), "NOT_USING_STATE")) {
+        if (Objects.equals(inquiry.getStrategy().getStatusCode(), StrategyStatusCode.PUBLIC.getCode())) {
             methodId = inquiry.getStrategy().getMethod().getId();
             methodIconPath = fileService.getFilePathNullable(new FileRequest(FileReferenceType.METHOD, methodId));
             cycle = inquiry.getStrategy().getCycle();
@@ -485,7 +486,7 @@ public class InquiryServiceImpl implements InquiryService {
         String strategyName;
         String statusCode;
 
-        if (!Objects.equals(inquiry.getStrategy().getStatusCode(), "NOT_USING_STATE")) {
+        if (Objects.equals(inquiry.getStrategy().getStatusCode(), StrategyStatusCode.PUBLIC.getCode())) {
             methodId = inquiry.getStrategy().getMethod().getId();
             methodIconPath = fileService.getFilePathNullable(new FileRequest(FileReferenceType.METHOD, methodId));
             cycle = inquiry.getStrategy().getCycle();
@@ -610,7 +611,7 @@ public class InquiryServiceImpl implements InquiryService {
         String strategyName;
         String statusCode;
 
-        if (!Objects.equals(inquiry.getStrategy().getStatusCode(), "NOT_USING_STATE")) {
+        if (Objects.equals(inquiry.getStrategy().getStatusCode(), StrategyStatusCode.PUBLIC.getCode())) {
             methodId = inquiry.getStrategy().getMethod().getId();
             methodIconPath = fileService.getFilePathNullable(new FileRequest(FileReferenceType.METHOD, methodId));
             cycle = inquiry.getStrategy().getCycle();

--- a/src/test/java/com/be3c/sysmetic/domain/member/service/InquiryServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/service/InquiryServiceTest.java
@@ -59,6 +59,7 @@ public class InquiryServiceTest {
 //        Strategy strategy1 = createStrategy("삼성전자");
 //        Strategy strategy2 = createStrategy("LG전자");
 //        Strategy strategy3 = createStrategy("애플");
+//        Strategy strategy3 = createStrategy("테슬라");
 //
 //        int countInquiry = 1;
 //        int countInquiryAnswer = 1;


### PR DESCRIPTION
# 🚀 Pull Request

문의 페이지에서 공개 상태 전략 외에는 '조회할 수 없는 전략'이라고 뜨게 수정

## #️⃣ 연관된 이슈

#278

## 📋 작업 내용

문의 페이지(목록, 상세)에서 공개 상태 전략 외에는 관련 부분 '조회할 수 없는 전략'이라고 뜨게 수정
트레이더 상세에서 로그인한 사람 아이디와 트레이더 아이디가 같은지 확인 수정